### PR TITLE
Fix: Progress display shows correct milestone after task completion

### DIFF
--- a/src/tools/checklist.py
+++ b/src/tools/checklist.py
@@ -169,6 +169,13 @@ class ChecklistParser:
                 return milestone
         return None
 
+    def get_milestone_by_index(self, index: int) -> Milestone | None:
+        """Get a specific milestone by its index number."""
+        for milestone in self.parse_milestones():
+            if milestone.index == index:
+                return milestone
+        return None
+
     def mark_task_complete(self, task: Task) -> None:
         """Mark a task as complete by updating the checkbox in the file."""
         # Line numbers are 1-indexed
@@ -426,12 +433,13 @@ class ChecklistExecutor(ToolExecutor[ChecklistAction, ChecklistObservation]):
 
         # Mark the task complete
         line_number = matching_task.line_number
+        milestone_index = milestone.index
         self.parser.mark_task_complete(matching_task)
 
-        # Re-parse to get updated counts
-        milestone = self.parser.get_current_milestone()
-        tasks_complete = milestone.tasks_complete if milestone else 0
-        tasks_remaining = milestone.tasks_remaining if milestone else 0
+        # Re-parse to get updated counts for the SAME milestone (not the next one)
+        updated_milestone = self.parser.get_milestone_by_index(milestone_index)
+        tasks_complete = updated_milestone.tasks_complete if updated_milestone else 0
+        tasks_remaining = updated_milestone.tasks_remaining if updated_milestone else 0
 
         return ChecklistObservation.from_text(
             text=f"Marked complete: {matching_task.description}",

--- a/tests/tools/test_checklist.py
+++ b/tests/tools/test_checklist.py
@@ -304,6 +304,26 @@ class TestChecklistExecutor:
         assert obs.is_error
         assert "no matching" in obs.text.lower()
 
+    def test_complete_last_task_shows_correct_progress(self, partial_doc: Path) -> None:
+        """Test that completing the last task shows 100% progress for that milestone.
+
+        Bug fix regression test: Previously, completing the last task would show 0%
+        progress because it retrieved the progress from the next milestone instead
+        of the one that was just completed (issue #6).
+        """
+        executor = ChecklistExecutor(partial_doc)
+        # Complete the last remaining task in milestone 1
+        action = ChecklistAction(command="complete", task_description="tests/test_feature.py")
+
+        obs = executor(action)
+
+        assert not obs.is_error
+        assert obs.command == "complete"
+        # Milestone 1 had 2 tasks (1 complete, 1 remaining)
+        # After completing the last task, it should show 2/2 complete (100%)
+        assert obs.tasks_complete == 2
+        assert obs.tasks_remaining == 0
+
     def test_missing_design_doc(self, temp_workspace: Path) -> None:
         """Test error when design doc doesn't exist."""
         missing_path = temp_workspace / "nonexistent.md"


### PR DESCRIPTION
## Summary

Fixes the confusing progress display issue where completing a task would show 0% progress instead of the correct percentage.

## Problem

After marking a task complete, the progress display was showing the progress of the **next** milestone (which could be 0%) instead of the milestone where the task was just completed.

For example, as reported in the issue:
- Milestone 3 was at 50% (1/2 tasks)
- After completing the last task, it showed 0% instead of 100%

## Root Cause

The bug was in `_handle_complete()` which used `get_current_milestone()` to get updated counts after marking a task complete. However, `get_current_milestone()` returns the first milestone with **incomplete** tasks. So if the task we just completed was the last remaining task in the milestone, it would return the **next** milestone instead of the one we just completed.

## Fix

1. Added `get_milestone_by_index()` method to `ChecklistParser` to retrieve a specific milestone by its index number
2. Modified `_handle_complete()` to:
   - Store the milestone index before completing the task
   - Use `get_milestone_by_index()` to retrieve the same milestone's updated counts (instead of possibly getting a different milestone)

## Testing

- Added a regression test `test_complete_last_task_shows_correct_progress` that verifies completing the last task in a milestone shows 100% progress (2/2 tasks, 0 remaining)
- All 119 existing tests continue to pass

Closes #6

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)