### PR TITLE
Fix: Gracefully handle missing journal file (issue #4)

### DIFF
--- a/src/agents/task_agent.py
+++ b/src/agents/task_agent.py
@@ -20,17 +20,23 @@ TASK_AGENT_SYSTEM_PROMPT = """\
 You are a Task Agent responsible for completing a single implementation task.
 
 WORKFLOW:
-1. Read the design document and journal to understand context
-2. Read any existing code relevant to your task
-3. Use TaskTrackerTool to plan your work - create specific tasks for your implementation
-4. Your task plan MUST include these quality steps at the end:
+1. Use the JournalTool with command="read" to read the journal for context from prior tasks.
+   This will create the journal if it doesn't exist - DO NOT skip this step or defer it.
+   If the journal is new (no prior entries), proceed - you are simply the first task.
+2. Read the design document to understand what you need to implement
+3. Read any existing code relevant to your task
+4. Use TaskTrackerTool to plan your work - create specific tasks for your implementation
+5. Your task plan MUST include these quality steps at the end:
    - Run tests and verify passing
    - Run lints (make lint), fix any issues
    - Run typecheck (make typecheck), fix any issues
    - Commit with a meaningful message describing what you implemented
-   - Write a journal entry summarizing files read/modified and lessons learned
-5. Execute your plan, marking each task complete as you finish it
-6. Do not skip quality steps - they are required for task completion
+   - Write a journal entry using JournalTool with command="append"
+6. Execute your plan, marking each task complete as you finish it
+7. Do not skip quality steps - they are required for task completion
+
+CRITICAL: Never defer journal operations. Use JournalTool to read the journal at the
+START and write an entry at the END. Do not use FileEditorTool for journal operations.
 
 JOURNAL ENTRY FORMAT:
 When writing your journal entry, include:


### PR DESCRIPTION
## Summary

This PR addresses issue #4 where the agent was deferring journal creation when the `journal.md` file didn't exist. Instead of deciding "I'll create it later" (which led to the agent using `FileEditorTool` to read a non-existent file), the agent should now handle this gracefully.

## Problem

When the journal file doesn't exist (e.g., on the first task), the Task Agent was:
1. Using `FileEditorTool` to try to read `doc/design/journal.md`
2. Getting an error "path does not exist"
3. Deciding to "create it later" and moving on
4. This deferred the journal creation, which goes against the design intent

## Solution

### 1. Add `read` command to JournalTool

The `JournalTool` now supports a `read` command that:
- Creates the journal file if it doesn't exist (with a proper header)
- Returns the journal contents to the agent
- Indicates whether this was a newly created journal (`was_created=True`)
- Counts the number of prior entries (`entry_count`)

This ensures the agent can always read the journal context without errors.

### 2. Update Task Agent System Prompt

The Task Agent prompt now:
- Explicitly instructs to use `JournalTool` with `command="read"` first
- Makes clear this creates the journal if missing - "DO NOT skip this step or defer it"
- Adds a **CRITICAL** instruction to never defer journal operations
- Specifies to use `JournalTool` (not `FileEditorTool`) for journal operations

## Changes

| File | Description |
|------|-------------|
| `src/tools/journal.py` | Added `read` command to `JournalAction`, updated `JournalObservation` with new fields (`journal_content`, `entry_count`, `was_created`), implemented `_read_journal()` method |
| `src/agents/task_agent.py` | Updated system prompt to use JournalTool read command, added CRITICAL instruction |
| `tests/tools/test_journal.py` | Added tests for read command (new journal, existing journal), visualization tests, and append without entry test |

## Testing

All 126 tests pass:
- ✅ `make test` 
- ✅ `make lint` 
- ✅ `make typecheck`

New tests added:
- `test_read_creates_file_if_not_exists` - verifies read creates new journal
- `test_read_existing_journal` - verifies read returns existing content
- `test_read_has_content_for_llm` - verifies SDK prompt caching compliance
- `test_append_without_entry_fails` - verifies proper error handling
- `test_read_action_visualization` - verifies UI display
- `test_read_success_visualization_new_journal` - verifies new journal UI
- `test_read_success_visualization_existing_journal` - verifies existing journal UI

Fixes #4

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)