### PR TITLE
feat(orchestrator): add ALL_MILESTONES_COMPLETE signal

### DIFF
--- a/src/agents/orchestrator.py
+++ b/src/agents/orchestrator.py
@@ -299,6 +299,8 @@ See `.pr/design.md` section 5.1
 COMPLETION:
 - When milestone is complete, comment "Ready for review" on PR and STOP
 - Report: "MILESTONE COMPLETE: <milestone name> - PR ready for review"
+- If ALL milestones in the design doc are complete (all checkboxes checked),
+  also output on its own line: ALL_MILESTONES_COMPLETE
 - Do NOT continue to next milestone until PR is merged
 """
 


### PR DESCRIPTION
## Summary

When all milestones in the design doc are complete (all checkboxes checked), the orchestrator now outputs `ALL_MILESTONES_COMPLETE` on its own line.

## Why

This enables the Ralph Loop (#18) to detect when work is done. The loop checks for this signal in the agent output to determine if the completion condition is met.

## Changes

- Updated `ORCHESTRATOR_SYSTEM_PROMPT` in `src/agents/orchestrator.py` to include instruction to output `ALL_MILESTONES_COMPLETE` when all tasks are done.

## Testing

This is a prompt change. The signal will appear when:
1. Orchestrator checks status and finds no remaining tasks
2. All milestones have all checkboxes marked complete

Closes #19

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)