### PR TITLE
feat(checklist): add all_milestones_complete field

### DIFF
--- a/tests/tools/test_checklist.py
+++ b/tests/tools/test_checklist.py
@@ -242,6 +242,27 @@ class TestChecklistExecutor:
 
         assert not obs.is_error
         assert obs.milestone_index is None
+        assert obs.all_milestones_complete is True
+
+    def test_status_not_all_complete(self, design_doc: Path) -> None:
+        """Test all_milestones_complete is False when tasks remain."""
+        executor = ChecklistExecutor(design_doc)
+        action = ChecklistAction(command="status")
+
+        obs = executor(action)
+
+        assert not obs.is_error
+        assert obs.all_milestones_complete is False
+
+    def test_status_partial_complete(self, partial_doc: Path) -> None:
+        """Test all_milestones_complete is False when some tasks remain."""
+        executor = ChecklistExecutor(partial_doc)
+        action = ChecklistAction(command="status")
+
+        obs = executor(action)
+
+        assert not obs.is_error
+        assert obs.all_milestones_complete is False
 
     def test_next_command(self, design_doc: Path) -> None:
         """Test next command returns next task."""


### PR DESCRIPTION
## Summary

Add an explicit `all_milestones_complete` boolean field to `ChecklistObservation` that indicates when all tasks in all milestones are complete.

## Why

Currently, callers must infer completion from `get_current_milestone() is None`. An explicit field is clearer and more reliable, especially for the Ralph Loop (#18) which needs to detect completion.

## Changes

- Add `all_milestones_complete` field to `ChecklistObservation`
- Update `_handle_status()` to compute the field by checking all milestones
- Add 3 tests for the new field:
  - `test_status_all_complete` - verifies True when all done
  - `test_status_not_all_complete` - verifies False when tasks remain
  - `test_status_partial_complete` - verifies False when some tasks done

## Testing

```bash
uv run pytest tests/tools/test_checklist.py -v
# 26 passed
```

Closes #20

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)