### PR TITLE
Add OpenHands automated PR review workflow

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -1,0 +1,42 @@
+---
+name: PR Review by OpenHands
+
+on:
+    pull_request:
+        types: [opened, ready_for_review, labeled, review_requested]
+
+permissions:
+    contents: read
+    pull-requests: write
+    issues: write
+
+jobs:
+    pr-review:
+        # Skip fork PRs (no access to secrets) and draft PRs
+        if: |
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            (
+                (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
+                github.event.action == 'ready_for_review' ||
+                (github.event.action == 'labeled' && github.event.label.name == 'review-this') ||
+                (
+                    github.event.action == 'review_requested' &&
+                    (
+                        github.event.requested_reviewer.login == 'openhands-agent' ||
+                        github.event.requested_reviewer.login == 'all-hands-bot'
+                    )
+                )
+            )
+        concurrency:
+            group: pr-review-${{ github.event.pull_request.number }}
+            cancel-in-progress: true
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Run PR Review
+              uses: OpenHands/extensions/plugins/pr-review@main
+              with:
+                  llm-model: litellm_proxy/claude-sonnet-4-5-20250929
+                  llm-base-url: https://llm-proxy.app.all-hands.dev
+                  review-style: roasted
+                  llm-api-key: ${{ secrets.LLM_API_KEY }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR adds an automated code review workflow using the [OpenHands PR Review action](https://github.com/OpenHands/extensions/tree/main/plugins/pr-review).

## How it works

The workflow triggers when:
- A PR is opened (non-draft)
- A PR is marked ready for review
- The `review-this` label is added
- `openhands-agent` or `all-hands-bot` is requested as a reviewer

## Review Style

Uses the "roasted" review style - Linus Torvalds-inspired brutally honest feedback that focuses on:
- Data structures and design choices
- Simplicity and pragmatism
- Real engineering concerns over ceremony

## Setup Required

For this workflow to function, you'll need to add the `LLM_API_KEY` secret to the repository:

1. Go to **Settings → Secrets and variables → Actions**
2. Add a new repository secret named `LLM_API_KEY`
3. Set the value to your LLM API key (for the litellm proxy endpoint)

## Security Notes

- Fork PRs are automatically skipped (no access to secrets)
- Draft PRs are skipped until marked ready for review
- Uses concurrency groups to cancel duplicate reviews

## Reference

This follows the same approach used by [OpenHands/OpenHands](https://github.com/OpenHands/OpenHands/blob/main/.github/workflows/pr-review-by-openhands.yml) for their own PR reviews.

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)