### PR TITLE
Add documentation for PR refinement feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,46 @@ The Ralph Loop:
 - Detects completion via `ALL_MILESTONES_COMPLETE` signal or design doc state
 - Stops after 3 consecutive failures for safety
 
+### PR Refinement Mode
+
+Refine an existing PR through automated code review and response:
+
+```bash
+# Run refinement on a PR (auto-detects which phase to run)
+lxa refine https://github.com/owner/repo/pull/42
+
+# Run with automatic merge when refinement passes
+lxa refine https://github.com/owner/repo/pull/42 --auto-merge
+
+# Specify a refinement phase
+lxa refine https://github.com/owner/repo/pull/42 --phase self-review
+lxa refine https://github.com/owner/repo/pull/42 --phase respond
+
+# Configure quality bar and iteration limits
+lxa refine URL --allow-merge good_taste --max-iterations 10
+```
+
+The refinement loop has two phases:
+- **Self-Review**: Agent reviews its own code using "roasted" code review principles,
+  fixes issues iteratively, and marks the PR ready for human review
+- **Respond**: Agent reads external review comments, addresses them systematically,
+  replies to threads with commit SHAs, and marks them resolved
+
+### Integrated Refinement with Loop Mode
+
+Combine implementation and refinement in a single command:
+
+```bash
+# Run until completion, then refine the PR
+lxa implement --loop --refine
+
+# With automatic merge after refinement passes
+lxa implement --loop --refine --auto-merge
+
+# Custom refinement settings
+lxa implement --loop --refine --allow-merge good_taste --max-refine-iterations 10
+```
+
 ### Reconciliation (Post-merge)
 
 Update design documents to reference implemented code:
@@ -91,3 +131,4 @@ make test-cov
 | Document | Description |
 |----------|-------------|
 | [Artifact Path Configuration](doc/reference/artifact-path-configuration.md) | `.pr/` folder pattern and configuration |
+| [PR Refinement](doc/reference/pr-refinement.md) | Two-phase code review and refinement loop |

--- a/doc/design/implementation-agent-design.md
+++ b/doc/design/implementation-agent-design.md
@@ -676,3 +676,45 @@ python -m src reconcile doc/design.md            # Apply changes
 
 - [x] src/skills/reconcile.py - Logic to find implementations and update design doc
 - [x] tests/skills/test_reconcile.py - Tests for reconciliation behavior
+
+### 5.6 PR Refinement Loop (M6)
+
+**Goal**: Automated two-phase code review loop that improves PR quality before
+merge.
+
+**Demo**: Run `lxa refine <PR_URL>` on an existing PR, observe self-review or
+review response depending on PR state.
+
+```bash
+# Run refinement on existing PR
+lxa refine https://github.com/owner/repo/pull/42
+
+# With automatic merge when refinement passes
+lxa refine https://github.com/owner/repo/pull/42 --auto-merge
+
+# Integrate with implementation loop
+lxa implement --loop --refine
+```
+
+See [PR Refinement Reference](../reference/pr-refinement.md) for full
+documentation.
+
+#### 5.6.1 Refinement Runner
+
+- [x] src/ralph/refine.py - `RefineRunner` with two-phase execution (self-review,
+      respond)
+- [x] src/ralph/refinement_config.py - Shared code review principles and
+      workflow configuration
+- [x] tests/ralph/test_refine_runner.py - Tests for phase detection and
+      execution
+
+#### 5.6.2 GitHub Review API
+
+- [x] src/ralph/github_review.py - API helpers for fetching, replying to, and
+      resolving review threads via GraphQL
+- [x] tests/utils/test_github.py - Tests for PR URL parsing and API helpers
+
+#### 5.6.3 CLI Integration
+
+- [x] src/__main__.py - `refine` subcommand and `--refine` flag for implement
+- [x] tests/test_cli_refine.py - Tests for refine CLI options

--- a/doc/reference/pr-refinement.md
+++ b/doc/reference/pr-refinement.md
@@ -1,0 +1,226 @@
+# PR Refinement
+
+## Overview
+
+PR Refinement is a two-phase code review loop that helps improve PR quality before
+merging. It automates both self-review (agent reviews its own code) and review
+response (agent addresses external reviewer comments).
+
+## Phases
+
+### Phase 1: Self-Review
+
+The agent reviews its own code changes before requesting human review:
+
+1. Checks out the PR branch
+2. Waits for CI to pass
+3. Reviews code diff against quality principles (data structures, simplicity, testing)
+4. Fixes any issues found, commits changes
+5. Pushes and waits for CI
+6. Outputs a verdict:
+   - 🟢 **Good taste** — Code is clean, ready for review
+   - 🟡 **Acceptable** — Works correctly, minor improvements possible
+   - 🔴 **Needs rework** — Continue fixing issues
+7. If 🟢 or 🟡: Marks PR ready for human review
+
+### Phase 2: Review Response
+
+After humans review the PR, the agent addresses their feedback:
+
+1. Checks out the PR branch
+2. Waits for CI to pass
+3. For each unresolved review thread:
+   - Understands the reviewer's request
+   - Makes the fix or improvement
+   - Commits with message: `Address review: [description]`
+4. Pushes all changes
+5. Waits for CI to pass
+6. For each thread:
+   - Replies with the commit SHA that addressed it
+   - Marks the thread as resolved
+
+## CLI Usage
+
+### Standalone Refinement
+
+Refine an existing PR:
+
+```bash
+# Auto-detect which phase to run based on PR state
+lxa refine https://github.com/owner/repo/pull/42
+
+# Explicitly run self-review phase
+lxa refine https://github.com/owner/repo/pull/42 --phase self-review
+
+# Explicitly run review response phase
+lxa refine https://github.com/owner/repo/pull/42 --phase respond
+```
+
+### Integrated with Implementation
+
+Run refinement after implementation completes:
+
+```bash
+# Implement with refinement
+lxa implement --loop --refine
+
+# With automatic merge when done
+lxa implement --loop --refine --auto-merge
+```
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--phase` | `auto` | Which phase to run: `auto`, `self-review`, `respond` |
+| `--auto-merge` | false | Squash & merge when refinement passes |
+| `--allow-merge` | `acceptable` | Quality bar: `good_taste` or `acceptable` |
+| `--min-iterations` | 1 | Minimum review iterations before accepting "acceptable" |
+| `--max-iterations` | 5 | Maximum refinement iterations |
+
+### Quality Bar
+
+The `--allow-merge` option controls when the PR is considered ready:
+
+- **`good_taste`**: Only merge when self-review verdict is 🟢 (highest quality)
+- **`acceptable`**: Merge when verdict is 🟢 or 🟡 (after min-iterations)
+
+## Code Review Principles
+
+Self-review uses "roasted" code review principles inspired by Linus Torvalds:
+
+1. **Data Structures First**
+   - Poor data structure choices create unnecessary complexity
+   - Look for data copying/transformation that could be eliminated
+
+2. **Simplicity and "Good Taste"**
+   - Functions with >3 levels of nesting need redesign
+   - Special cases that could be eliminated with better design
+
+3. **Pragmatism**
+   - Is this solving a problem that actually exists?
+   - Are we over-engineering for theoretical edge cases?
+
+4. **Testing**
+   - New behavior needs tests that prove it works
+   - Tests should fail if the behavior regresses
+
+5. **Skip Style Nits**
+   - Formatting, naming conventions = linter territory
+
+## GitHub Integration
+
+The refinement loop uses GitHub's GraphQL API for review thread management:
+
+### Fetching Unresolved Threads
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: PR_NUMBER) {
+      reviewThreads(first: 50) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first: 1) {
+            nodes { body author { login } }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+### Replying to a Thread
+
+```bash
+gh api graphql -f query='
+mutation {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: "THREAD_ID"
+    body: "Fixed in abc1234"
+  }) {
+    comment { id }
+  }
+}'
+```
+
+### Resolving a Thread
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "THREAD_ID"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+## Implementation Details
+
+### Components
+
+| Module | Description |
+|--------|-------------|
+| `src/ralph/refine.py` | `RefineRunner` class and phase agents |
+| `src/ralph/github_review.py` | GitHub API helpers for review threads |
+| `src/ralph/refinement_config.py` | Shared review principles and workflows |
+| `src/ralph/state.py` | Refinement state tracking |
+
+### State Management
+
+Refinement state is tracked in memory by `RefineRunner`:
+- Current phase (self-review or respond)
+- Iteration count
+- Threads resolved count
+- Verdict history
+
+### CI Integration
+
+Before each phase, the runner:
+1. Polls PR check status via `gh pr checks`
+2. Waits for all checks to complete
+3. Reports CI status (passing, failing, pending)
+4. If CI fails, the agent is instructed to fix issues before proceeding
+
+## Workflow Diagram
+
+```
+┌─────────────────┐
+│  PR Created     │
+│  (draft)        │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐     ┌─────────────────┐
+│  Self-Review    │────►│  Mark PR Ready  │
+│  Phase 1        │     │  for Review     │
+└────────┬────────┘     └────────┬────────┘
+         │                       │
+    Fix issues              Human reviews
+         │                       │
+         ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐
+│  Wait for CI    │     │  Review         │
+│                 │     │  Comments       │
+└─────────────────┘     └────────┬────────┘
+                                 │
+                                 ▼
+                        ┌─────────────────┐
+                        │  Respond        │
+                        │  Phase 2        │
+                        └────────┬────────┘
+                                 │
+                            Address &
+                            resolve threads
+                                 │
+                                 ▼
+                        ┌─────────────────┐
+                        │  Merge          │
+                        │  (if auto)      │
+                        └─────────────────┘
+```


### PR DESCRIPTION
## Summary

This PR adds the missing documentation for the PR refinement feature introduced in commit 1c8a9d9306fd25ef399c653b5c08cb2c24aa908a.

## Changes

### README.md
- Added usage examples for the new `lxa refine` command
- Added documentation for the `--refine` flag with `lxa implement --loop`
- Added link to the new reference documentation in the Documentation table

### doc/reference/pr-refinement.md (new file)
Comprehensive reference documentation covering:
- Two-phase refinement loop overview (Self-Review and Respond phases)
- CLI usage examples for standalone and integrated refinement
- Configuration options table (--phase, --auto-merge, --allow-merge, etc.)
- Code review principles used by the self-review phase
- GitHub GraphQL API usage for review thread management
- Implementation details and component mapping
- Workflow diagram

### doc/design/implementation-agent-design.md
- Added milestone 5.6 "PR Refinement Loop" to the implementation plan
- Documents the refinement runner, GitHub review API, and CLI integration
- Links to the new reference documentation

## Context

Commit 1c8a9d9 added significant new functionality:
- New CLI command: `lxa refine PR_URL [options]`
- New flags for `lxa implement --loop`: `--refine`, `--auto-merge`, `--allow-merge`, `--min-iterations`, `--max-refine-iterations`
- Two-phase refinement loop with self-review and review response capabilities

The original commit did not include documentation updates, which this PR addresses.

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)