### PR TITLE
Add version command and global install support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
-.PHONY: help install dev lint format typecheck test test-cov clean all check
+.PHONY: help install install-global uninstall-global dev lint format typecheck test test-cov clean all check
 
 # Default target
 help:
 	@echo "Long Horizon Agent - Development Commands"
 	@echo ""
 	@echo "Setup:"
-	@echo "  make install    Install production dependencies"
-	@echo "  make dev        Install development dependencies"
+	@echo "  make install          Install in local venv (editable)"
+	@echo "  make install-global   Install lxa globally with uv"
+	@echo "  make uninstall-global Uninstall global lxa"
+	@echo "  make dev              Install development dependencies"
 	@echo ""
 	@echo "Code Quality:"
 	@echo "  make lint       Run ruff linter"
@@ -22,9 +24,20 @@ help:
 	@echo "  make clean      Remove build artifacts and caches"
 	@echo "  make all        Run all checks and tests"
 
-# Install production dependencies
+# Install in local venv (editable mode for development)
 install:
 	uv pip install -e .
+
+# Install lxa globally using uv tool
+# This makes 'lxa' available system-wide without activating a venv
+install-global:
+	uv tool install --force .
+	@echo ""
+	@echo "lxa installed globally. Run 'lxa --version' to verify."
+
+# Uninstall global lxa
+uninstall-global:
+	uv tool uninstall lxa || true
 
 # Install development dependencies
 dev:

--- a/README.md
+++ b/README.md
@@ -3,14 +3,40 @@
 An autonomous agent built with the [OpenHands
 SDK](https://github.com/All-Hands-AI/openhands) for long-horizon task execution.
 
-## Setup
+## Installation
+
+### Global Install (Recommended)
+
+Install `lxa` globally so it's available from anywhere:
 
 ```bash
-# Install dependencies
+# Install globally with uv
+make install-global
+
+# Verify installation
+lxa --version
+```
+
+### Development Install
+
+For development, install in editable mode:
+
+```bash
+# Install with dev dependencies
 uv pip install -e ".[dev]"
 
 # Or using make
 make dev
+```
+
+### Version Information
+
+Check your installed version:
+
+```bash
+lxa --version
+# Output: lxa 0.1.0 (abc1234)  - clean build with git SHA
+# Output: lxa 0.1.0 (abc1234, dirty)  - local build with uncommitted changes
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lxa"
-version = "0.1.0"
+dynamic = ["version"]
 description = "LXA (Long Execution Agent) - Agent-assisted software development"
 requires-python = ">=3.12"
 dependencies = [
@@ -26,6 +26,9 @@ lxa = "src.__main__:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -396,6 +396,14 @@ def main(argv: list[str] | None = None) -> int:
     Returns:
         Exit code
     """
+    from src._version import get_full_version_string
+
+    # Handle --version before argparse (argparse requires subcommand otherwise)
+    args_to_check = argv if argv is not None else sys.argv[1:]
+    if "--version" in args_to_check or "-V" in args_to_check:
+        print(get_full_version_string())
+        return 0
+
     parser = argparse.ArgumentParser(
         prog="lxa",
         description="LXA (Long Execution Agent) - Agent-assisted software development",

--- a/src/_version.py
+++ b/src/_version.py
@@ -19,7 +19,7 @@ def get_git_info() -> dict[str, str | None]:
     """Get git information for version display.
 
     Returns:
-        Dict with "sha" (short commit hash or None) and "dirty" ("true"/"false"/None)
+        Dict with "sha" (short commit hash or None) and "local" ("true"/"false"/None)
     """
     try:
         sha = subprocess.run(
@@ -28,7 +28,7 @@ def get_git_info() -> dict[str, str | None]:
             text=True,
             timeout=5,
         )
-        dirty = subprocess.run(
+        local = subprocess.run(
             ["git", "status", "--porcelain"],
             capture_output=True,
             text=True,
@@ -36,10 +36,10 @@ def get_git_info() -> dict[str, str | None]:
         )
         return {
             "sha": sha.stdout.strip() if sha.returncode == 0 else None,
-            "dirty": "true" if dirty.stdout.strip() else "false",
+            "local": "true" if local.stdout.strip() else "false",
         }
     except (subprocess.SubprocessError, FileNotFoundError, OSError):
-        return {"sha": None, "dirty": None}
+        return {"sha": None, "local": None}
 
 
 def get_version() -> str:
@@ -61,7 +61,7 @@ def get_version_info() -> dict[str, str | None]:
     return {
         "version": __version__,
         "git_sha": git_info["sha"],
-        "git_dirty": git_info["dirty"],
+        "git_local": git_info["local"],
     }
 
 
@@ -69,7 +69,7 @@ def get_full_version_string() -> str:
     """Get a human-readable version string with build info.
 
     Returns:
-        String like "lxa 0.1.0 (abc1234)" or "lxa 0.1.0 (abc1234, dirty)"
+        String like "lxa 0.1.0 (abc1234)" or "lxa 0.1.0 (abc1234, local)"
     """
     info = get_version_info()
     parts = [f"lxa {info['version']}"]
@@ -77,8 +77,8 @@ def get_full_version_string() -> str:
     details = []
     if info["git_sha"]:
         details.append(info["git_sha"])
-    if info["git_dirty"] == "true":
-        details.append("dirty")
+    if info["git_local"] == "true":
+        details.append("local")
 
     if details:
         parts.append(f"({', '.join(details)})")

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,0 +1,86 @@
+"""Version information for LXA.
+
+This module provides version information that can distinguish between:
+- CI builds: have git SHA and clean build info
+- Local/dev builds: show "local" as build type
+
+The version is statically defined here and should match pyproject.toml.
+Build metadata is injected by CI or detected at runtime.
+"""
+
+import subprocess
+from functools import lru_cache
+
+__version__ = "0.1.0"
+
+
+@lru_cache(maxsize=1)
+def get_git_info() -> dict[str, str | None]:
+    """Get git information for version display.
+
+    Returns:
+        Dict with 'sha' (short commit hash) and 'dirty' (bool as string)
+    """
+    try:
+        sha = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        dirty = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return {
+            "sha": sha.stdout.strip() if sha.returncode == 0 else None,
+            "dirty": "true" if dirty.stdout.strip() else "false",
+        }
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return {"sha": None, "dirty": None}
+
+
+def get_version() -> str:
+    """Get the version string.
+
+    Returns:
+        Version string like "0.1.0"
+    """
+    return __version__
+
+
+def get_version_info() -> dict[str, str | None]:
+    """Get detailed version information.
+
+    Returns:
+        Dict with version details including build info
+    """
+    git_info = get_git_info()
+    return {
+        "version": __version__,
+        "git_sha": git_info["sha"],
+        "git_dirty": git_info["dirty"],
+    }
+
+
+def get_full_version_string() -> str:
+    """Get a human-readable version string with build info.
+
+    Returns:
+        String like "lxa 0.1.0 (abc1234, local)" or "lxa 0.1.0 (abc1234)"
+    """
+    info = get_version_info()
+    parts = [f"lxa {info['version']}"]
+
+    details = []
+    if info["git_sha"]:
+        details.append(info["git_sha"])
+    if info["git_dirty"] == "true":
+        details.append("dirty")
+
+    if details:
+        parts.append(f"({', '.join(details)})")
+
+    return " ".join(parts)

--- a/src/_version.py
+++ b/src/_version.py
@@ -19,7 +19,7 @@ def get_git_info() -> dict[str, str | None]:
     """Get git information for version display.
 
     Returns:
-        Dict with 'sha' (short commit hash) and 'dirty' (bool as string)
+        Dict with "sha" (short commit hash or None) and "dirty" ("true"/"false"/None)
     """
     try:
         sha = subprocess.run(
@@ -69,7 +69,7 @@ def get_full_version_string() -> str:
     """Get a human-readable version string with build info.
 
     Returns:
-        String like "lxa 0.1.0 (abc1234, local)" or "lxa 0.1.0 (abc1234)"
+        String like "lxa 0.1.0 (abc1234)" or "lxa 0.1.0 (abc1234, dirty)"
     """
     info = get_version_info()
     parts = [f"lxa {info['version']}"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -37,14 +37,14 @@ class TestVersionModule:
         info = get_version_info()
         assert "version" in info
         assert "git_sha" in info
-        assert "git_dirty" in info
+        assert "git_local" in info
         assert info["version"] == __version__
 
     def test_get_git_info_returns_dict(self) -> None:
-        """get_git_info should return dict with sha and dirty keys."""
+        """get_git_info should return dict with sha and local keys."""
         info = get_git_info()
         assert "sha" in info
-        assert "dirty" in info
+        assert "local" in info
 
     def test_get_full_version_string_starts_with_lxa(self) -> None:
         """Full version string should start with 'lxa'."""

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,86 @@
+"""Tests for version module."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from src.__main__ import main
+from src._version import (
+    __version__,
+    get_full_version_string,
+    get_git_info,
+    get_version,
+    get_version_info,
+)
+
+
+class TestVersionModule:
+    """Tests for version module functions."""
+
+    def test_version_is_string(self) -> None:
+        """__version__ should be a string."""
+        assert isinstance(__version__, str)
+
+    def test_version_format(self) -> None:
+        """Version should follow semver pattern."""
+        parts = __version__.split(".")
+        assert len(parts) >= 2
+        assert all(p.isdigit() for p in parts[:2])
+
+    def test_get_version_returns_version(self) -> None:
+        """get_version should return the version string."""
+        assert get_version() == __version__
+
+    def test_get_version_info_structure(self) -> None:
+        """get_version_info should return dict with expected keys."""
+        info = get_version_info()
+        assert "version" in info
+        assert "git_sha" in info
+        assert "git_dirty" in info
+        assert info["version"] == __version__
+
+    def test_get_git_info_returns_dict(self) -> None:
+        """get_git_info should return dict with sha and dirty keys."""
+        info = get_git_info()
+        assert "sha" in info
+        assert "dirty" in info
+
+    def test_get_full_version_string_starts_with_lxa(self) -> None:
+        """Full version string should start with 'lxa'."""
+        version_str = get_full_version_string()
+        assert version_str.startswith("lxa ")
+        assert __version__ in version_str
+
+
+class TestVersionCLI:
+    """Tests for --version CLI flag."""
+
+    def test_version_flag_returns_zero(self) -> None:
+        """--version should return exit code 0."""
+        result = main(["--version"])
+        assert result == 0
+
+    def test_short_version_flag_returns_zero(self) -> None:
+        """-V should return exit code 0."""
+        result = main(["-V"])
+        assert result == 0
+
+    def test_version_flag_prints_version(self, capsys) -> None:
+        """--version should print version string."""
+        main(["--version"])
+        captured = capsys.readouterr()
+        assert "lxa" in captured.out
+        assert __version__ in captured.out
+
+    def test_version_via_subprocess(self) -> None:
+        """Version should work when invoked via subprocess."""
+        result = subprocess.run(
+            ["python", "-m", "src", "--version"],
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).parent.parent,
+        )
+        assert result.returncode == 0
+        assert "lxa" in result.stdout
+        assert __version__ in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -1617,7 +1617,6 @@ wheels = [
 
 [[package]]
 name = "lxa"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "mdformat" },


### PR DESCRIPTION
## Summary

Add `lxa --version` command and `make install-global` for easy system-wide installation with uv.

## Changes

### Version Module (`src/_version.py`)
- Single source of truth for version: `__version__ = "0.1.0"`
- Git info detection: shows commit SHA and dirty/clean status
- Functions: `get_version()`, `get_version_info()`, `get_full_version_string()`

### CLI Version Command
- `lxa --version` or `lxa -V` prints version info and exits
- Example output:
  - `lxa 0.1.0 (abc1234)` - clean build with git SHA
  - `lxa 0.1.0 (abc1234, dirty)` - local build with uncommitted changes

### Dynamic Version in pyproject.toml
- Version is now read from `src/_version.py` using hatchling's dynamic versioning
- Single place to update version for releases

### Global Install Commands (Makefile)
- `make install-global` - Install lxa system-wide using `uv tool install`
- `make uninstall-global` - Uninstall global lxa

### Tests
- 10 new test cases in `tests/test_version.py`
- All 448 tests pass

## Usage

```bash
# Install globally
make install-global

# Check version
lxa --version

# Uninstall globally  
make uninstall-global
```
