### PR TITLE
Fix delegate tool agent registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ dynamic = ["version"]
 description = "LXA (Long Execution Agent) - Agent-assisted software development"
 requires-python = ">=3.12"
 dependencies = [
-    "openhands-sdk>=0.9.0",
-    "openhands-tools>=1.7.0",
+    "openhands-sdk>=1.12.0",
+    "openhands-tools>=1.12.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",
     "mdformat>=0.7",

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -30,8 +30,12 @@ if "LOG_LEVEL" not in os.environ:
 
 from dotenv import load_dotenv
 from openhands.sdk import LLM, Conversation
-from openhands.sdk.subagent import register_agent_if_absent  # pyright: ignore[reportMissingImports]
-from openhands.tools import register_builtins_agents  # pyright: ignore[reportAttributeAccessIssue]
+from openhands.sdk.subagent import (  # pyright: ignore[reportMissingImports]
+    register_agent_if_absent,
+)
+from openhands.tools import (  # pyright: ignore[reportAttributeAccessIssue]
+    register_builtins_agents,
+)
 from openhands.tools.delegate import DelegationVisualizer
 from rich.console import Console
 from rich.panel import Panel

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -30,6 +30,8 @@ if "LOG_LEVEL" not in os.environ:
 
 from dotenv import load_dotenv
 from openhands.sdk import LLM, Conversation
+from openhands.sdk.subagent import register_agent_if_absent
+from openhands.tools import register_builtins_agents
 from openhands.tools.delegate import DelegationVisualizer
 from rich.console import Console
 from rich.panel import Panel
@@ -40,6 +42,7 @@ from src.agents.orchestrator import (
     create_orchestrator_agent,
     run_preflight_checks,
 )
+from src.agents.task_agent import create_task_agent
 from src.config import DEFAULT_DESIGN_PATH, load_config
 from src.ralph.runner import DEFAULT_CONVERSATIONS_DIR, RefinementConfig
 from src.skills.reconcile import reconcile_design_doc
@@ -49,6 +52,23 @@ from src.utils.github import parse_pr_url
 load_dotenv()
 
 console = Console()
+
+
+def _register_agents() -> None:
+    """Register agent types for delegation.
+
+    This must be called before creating any orchestrator agent that uses
+    the DelegateTool, as the tool looks up agent factories from the registry.
+    """
+    # Register builtin agents (includes "default" agent)
+    register_builtins_agents(cli_mode=True)
+
+    # Register task_agent for orchestrator delegation
+    register_agent_if_absent(
+        name="task_agent",
+        factory_func=create_task_agent,
+        description="Short-lived agent for completing single implementation tasks",
+    )
 
 CONVERSATIONS_DIR = DEFAULT_CONVERSATIONS_DIR
 
@@ -403,6 +423,9 @@ def main(argv: list[str] | None = None) -> int:
     if "--version" in args_to_check or "-V" in args_to_check:
         print(get_full_version_string())
         return 0
+
+    # Register agent types for delegation (must happen before orchestrator runs)
+    _register_agents()
 
     parser = argparse.ArgumentParser(
         prog="lxa",

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -30,8 +30,8 @@ if "LOG_LEVEL" not in os.environ:
 
 from dotenv import load_dotenv
 from openhands.sdk import LLM, Conversation
-from openhands.sdk.subagent import register_agent_if_absent
-from openhands.tools import register_builtins_agents
+from openhands.sdk.subagent import register_agent_if_absent  # pyright: ignore[reportMissingImports]
+from openhands.tools import register_builtins_agents  # pyright: ignore[reportAttributeAccessIssue]
 from openhands.tools.delegate import DelegationVisualizer
 from rich.console import Console
 from rich.panel import Panel

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -70,6 +70,7 @@ def _register_agents() -> None:
         description="Short-lived agent for completing single implementation tasks",
     )
 
+
 CONVERSATIONS_DIR = DEFAULT_CONVERSATIONS_DIR
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from src.__main__ import find_git_root, main
+from src.__main__ import _register_agents, find_git_root, main
 
 
 class TestFindGitRoot:
@@ -148,3 +148,50 @@ class TestCLIIntegration:
         )
         assert "implement" in result.stdout
         assert "reconcile" in result.stdout
+
+
+class TestAgentRegistration:
+    """Tests for agent registration at CLI startup."""
+
+    def test_register_agents_registers_builtins(self) -> None:
+        """_register_agents should register builtin agents including 'bash'."""
+        from openhands.sdk.subagent import get_agent_factory
+
+        _register_agents()
+
+        # Builtin agents should be registered
+        bash_factory = get_agent_factory("bash")
+        assert bash_factory is not None, "bash agent should be registered"
+
+    def test_register_agents_registers_task_agent(self) -> None:
+        """_register_agents should register the task_agent."""
+        from openhands.sdk.subagent import get_agent_factory
+
+        _register_agents()
+
+        # task_agent should be registered
+        task_factory = get_agent_factory("task_agent")
+        assert task_factory is not None, "task_agent should be registered"
+
+    def test_register_agents_idempotent(self) -> None:
+        """_register_agents should be safe to call multiple times."""
+        from openhands.sdk.subagent import get_agent_factory
+
+        # Call multiple times - should not raise
+        _register_agents()
+        _register_agents()
+        _register_agents()
+
+        # Agents should still be registered
+        assert get_agent_factory("bash") is not None
+        assert get_agent_factory("task_agent") is not None
+
+    def test_agents_available_in_registry_info(self) -> None:
+        """Registered agents should appear in registry info."""
+        from openhands.sdk.subagent.registry import get_factory_info
+
+        _register_agents()
+
+        info = get_factory_info()
+        assert "bash" in info, "bash should appear in registry info"
+        assert "task_agent" in info, "task_agent should appear in registry info"


### PR DESCRIPTION
## Summary

Fixes #45 - The delegate tool fails to spawn task agents during `lxa implement --loop` because no agent types are registered in the OpenHands SDK's agent registry.

## Root Cause

When running the orchestrator, the `DelegateTool` attempts to spawn sub-agents but fails with:
```
Error: failed to spawn agents: Unknown agent 'default'.
Available types: none registered. Use register_agent() to add custom agent types.
```

This happens because:
1. The orchestrator uses `DelegateTool` to delegate work to sub-agents
2. The `DelegateTool` looks up agent factories from the SDK's agent registry
3. No agents were ever registered - neither builtin agents nor the custom `task_agent`

## Solution

Register agent types at CLI startup in `src/__main__.py`:

1. **Import SDK registration functions**: `register_agent_if_absent` and `register_builtins_agents`
2. **Add `_register_agents()` helper**: Registers builtin agents (including "default") and the custom `task_agent`
3. **Call `_register_agents()` in `main()`**: Ensures agents are available before any orchestrator runs

This follows the pattern shown in the [SDK delegation examples](https://github.com/OpenHands/software-agent-sdk/blob/main/examples/01_standalone_sdk/25_agent_delegation.py).

## Changes

- `src/__main__.py`: Added agent registration imports, helper function, and call in main()
- `tests/test_cli.py`: Added `TestAgentRegistration` class with 4 tests

## Version Bump Explanation

The dependency versions were updated from `openhands-sdk>=0.9.0` to `>=1.12.0` because:

1. **`register_builtins_agents()`**: This function in `openhands.tools` was added in a later version. It registers the builtin subagents (bash, explore, default cli mode) that the DelegateTool needs.

2. **`register_agent_if_absent()`**: This function in `openhands.sdk.subagent` provides safe, idempotent agent registration. Earlier versions may have had different registration APIs.

3. **API stability**: The 1.12.0 version has the stable subagent registry API with `get_agent_factory()` and `get_factory_info()` used in our tests.

The version bump aligns lxa with the current SDK release where these delegation patterns are documented and stable.

## Testing

- All existing tests pass
- Added 4 new tests verifying:
  - Builtin agents are registered (bash, explore, etc.)
  - task_agent is registered for orchestrator delegation
  - Registration is idempotent (safe to call multiple times)
  - Registered agents appear in registry info

## Verification

After this fix, running `lxa implement doc/design/design-composition-agent.md --loop` should allow the orchestrator to successfully delegate tasks to sub-agents.