### PR TITLE
Rename markdown tool 'parse' command to 'overview' for better discoverability

### DIFF
--- a/doc/design/markdown-tool.md
+++ b/doc/design/markdown-tool.md
@@ -520,8 +520,8 @@ All tasks require:
 - [x] tests/tools/markdown/test_parser.py - Tests for parsing headings, nesting,
       TOC detection, numbered vs unnumbered sections
 - [x] src/tools/markdown/tool.py - `MarkdownDocumentTool` base structure
-- [x] src/tools/markdown/tool.py - parse command
-- [x] tests/tools/markdown/test_tool.py - Integration tests for parse command
+- [x] src/tools/markdown/tool.py - overview command
+- [x] tests/tools/markdown/test_tool.py - Integration tests for overview command
 
 ### 4.2 Validation and Renumbering (M2)
 

--- a/src/tools/markdown/tool.py
+++ b/src/tools/markdown/tool.py
@@ -30,12 +30,15 @@ MARKDOWN_TOOL_DESCRIPTION = """
 Markdown Document Tool for structural editing and formatting of markdown documents.
 
 This tool provides commands for:
+- Overview of document structure (sections, line numbers, hierarchy)
 - Validating document structure (section numbering consistency)
 - Renumbering sections sequentially
-- Parsing and analyzing document structure
 - Managing table of contents (generate, update, remove)
 - Section operations (move, insert, delete, promote, demote)
 - Formatting (rewrap paragraphs, lint, auto-fix issues)
+
+RECOMMENDED WORKFLOW: Start with 'overview' to see the document's hierarchical
+structure and locate sections by number or title before making structural edits.
 
 The tool helps maintain consistent markdown document structure and numbering.
 """.strip()
@@ -43,9 +46,9 @@ The tool helps maintain consistent markdown document structure and numbering.
 # Command visualization metadata: (icon, style, label_template)
 # label_template can use {section} or {heading} placeholders
 ACTION_DISPLAY: dict[str, tuple[str, str, str]] = {
+    "overview": ("📄 ", "blue", "Document Structure Overview"),
     "validate": ("🔍 ", "blue", "Validate Document Structure"),
     "renumber": ("🔢 ", "green", "Renumber Sections"),
-    "parse": ("📄 ", "yellow", "Parse Document Structure"),
     "toc_update": ("📑 ", "cyan", "Update Table of Contents"),
     "toc_remove": ("🗑️ ", "red", "Remove Table of Contents"),
     "move": ("↔️ ", "magenta", "Move Section '{section}'"),
@@ -64,9 +67,9 @@ class MarkdownAction(Action):
     """Action for the markdown document tool."""
 
     command: Literal[
+        "overview",
         "validate",
         "renumber",
-        "parse",
         "toc_update",
         "toc_remove",
         "move",
@@ -80,8 +83,11 @@ class MarkdownAction(Action):
         "cleanup",
     ] = Field(
         description=(
-            "Command to execute: 'validate' checks structure, 'renumber' fixes numbering, "
-            "'parse' shows structure, 'toc_update' generates/updates TOC, 'toc_remove' removes TOC, "
+            "Command to execute: "
+            "'overview' shows document structure with section titles, numbers, and line ranges - "
+            "use this FIRST when working with an unfamiliar document to understand its organization; "
+            "'validate' checks structure, 'renumber' fixes numbering, "
+            "'toc_update' generates/updates TOC, 'toc_remove' removes TOC, "
             "'move' moves a section, 'insert' inserts a new section, 'delete' removes a section, "
             "'promote' increases heading level (### → ##), 'demote' decreases heading level (## → ###), "
             "'rewrap' normalizes line lengths, 'lint' checks for issues, 'fix' auto-fixes issues, "
@@ -130,9 +136,9 @@ class MarkdownObservation(Observation):
     """Observation from the markdown document tool."""
 
     command: Literal[
+        "overview",
         "validate",
         "renumber",
-        "parse",
         "toc_update",
         "toc_remove",
         "move",
@@ -244,8 +250,8 @@ class MarkdownObservation(Observation):
             if self.toc_skipped:
                 text.append(" (TOC skipped)", style="dim")
 
-        elif self.command == "parse":
-            text.append(f"Parsed {self.total_sections} sections", style="blue")
+        elif self.command == "overview":
+            text.append(f"Document has {self.total_sections} sections", style="blue")
             if self.document_title:
                 text.append(f" - Title: {self.document_title}", style="dim")
 
@@ -402,8 +408,8 @@ class MarkdownExecutor(ToolExecutor[MarkdownAction, MarkdownObservation]):
 
             # Command handlers: read-only commands vs. commands that modify files
             read_only_handlers = {
+                "overview": self._overview_document,
                 "validate": self._validate_document,
-                "parse": self._parse_document,
                 "lint": self._lint_document,
             }
             mutating_handlers = {
@@ -488,8 +494,8 @@ class MarkdownExecutor(ToolExecutor[MarkdownAction, MarkdownObservation]):
             toc_skipped=result.toc_skipped,
         )
 
-    def _parse_document(self, action: MarkdownAction, content: str) -> MarkdownObservation:
-        """Parse document and return structure information."""
+    def _overview_document(self, action: MarkdownAction, content: str) -> MarkdownObservation:
+        """Return document structure overview with sections, hierarchy, and line numbers."""
         parser = MarkdownParser()
         result = parser.parse_content(content)
 

--- a/tests/tools/markdown/test_tool.py
+++ b/tests/tools/markdown/test_tool.py
@@ -1256,3 +1256,28 @@ Clean paragraph.
         text = obs.visualize
         assert "Fixed 3" in str(text)
         assert "1 remaining" in str(text)
+
+
+class TestDeprecatedCommands:
+    """Tests documenting intentional breaking changes to the command API."""
+
+    def test_parse_command_no_longer_valid(self):
+        """Document that 'parse' command was intentionally removed.
+
+        The 'parse' command was renamed to 'overview' for better discoverability.
+        This is a deliberate breaking change. Callers using 'parse' must update
+        to use 'overview' instead.
+        """
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            MarkdownAction(command="parse", file="test.md")
+
+        error = str(exc_info.value)
+        assert "parse" in error.lower() or "literal" in error.lower()
+
+    def test_overview_replaces_parse(self):
+        """Verify 'overview' is the replacement for deprecated 'parse' command."""
+        action = MarkdownAction(command="overview", file="test.md")
+        assert action.command == "overview"

--- a/tests/tools/markdown/test_tool.py
+++ b/tests/tools/markdown/test_tool.py
@@ -1256,4 +1256,3 @@ Clean paragraph.
         text = obs.visualize
         assert "Fixed 3" in str(text)
         assert "1 remaining" in str(text)
-

--- a/tests/tools/markdown/test_tool.py
+++ b/tests/tools/markdown/test_tool.py
@@ -152,8 +152,8 @@ This is the methods section.
         assert "## 1. Introduction" in updated_content
         assert "## 2. Methods" in updated_content
 
-    def test_parse_document(self):
-        """Test parsing a document and returning structure."""
+    def test_overview_document(self):
+        """Test overview command returns document structure and returning structure."""
         content = """# My Document
 
 ## Table of Contents
@@ -177,10 +177,10 @@ This is the methods section.
         test_file = self.temp_dir / "test.md"
         test_file.write_text(content)
 
-        action = MarkdownAction(command="parse", file="test.md")
+        action = MarkdownAction(command="overview", file="test.md")
         observation = self.executor.execute(action)
 
-        assert observation.command == "parse"
+        assert observation.command == "overview"
         assert observation.file == "test.md"
         assert observation.result == "success"
         assert observation.document_title == "My Document"
@@ -243,10 +243,10 @@ This is the methods section.
         test_file = self.temp_dir / "empty.md"
         test_file.write_text("")
 
-        action = MarkdownAction(command="parse", file="empty.md")
+        action = MarkdownAction(command="overview", file="empty.md")
         observation = self.executor.execute(action)
 
-        assert observation.command == "parse"
+        assert observation.command == "overview"
         assert observation.file == "empty.md"
         assert observation.result == "success"
         assert observation.document_title is None
@@ -318,7 +318,7 @@ This is deeply nested.
         test_file.write_text(content)
 
         # Parse should handle deep nesting
-        action = MarkdownAction(command="parse", file="complex.md")
+        action = MarkdownAction(command="overview", file="complex.md")
         observation = self.executor.execute(action)
 
         assert observation.result == "success"
@@ -521,9 +521,9 @@ class TestMarkdownAction:
         text = action.visualize
         assert "Renumber Sections" in str(text)
 
-        action = MarkdownAction(command="parse", file="test.md")
+        action = MarkdownAction(command="overview", file="test.md")
         text = action.visualize
-        assert "Parse Document Structure" in str(text)
+        assert "Document Structure Overview" in str(text)
 
         action = MarkdownAction(command="toc_update", file="test.md")
         text = action.visualize
@@ -581,17 +581,17 @@ class TestMarkdownObservation:
         assert "Renumbered 5 sections" in str(text)
         assert "TOC skipped" in str(text)
 
-    def test_observation_visualization_parse(self):
-        """Test observation visualization for parse command."""
+    def test_observation_visualization_overview(self):
+        """Test observation visualization for overview command."""
         obs = MarkdownObservation(
-            command="parse",
+            command="overview",
             file="test.md",
             result="success",
             total_sections=3,
             document_title="Test Document",
         )
         text = obs.visualize
-        assert "Parsed 3 sections" in str(text)
+        assert "Document has 3 sections" in str(text)
         assert "Test Document" in str(text)
 
     def test_observation_visualization_error(self):

--- a/tests/tools/markdown/test_tool.py
+++ b/tests/tools/markdown/test_tool.py
@@ -1257,27 +1257,3 @@ Clean paragraph.
         assert "Fixed 3" in str(text)
         assert "1 remaining" in str(text)
 
-
-class TestDeprecatedCommands:
-    """Tests documenting intentional breaking changes to the command API."""
-
-    def test_parse_command_no_longer_valid(self):
-        """Document that 'parse' command was intentionally removed.
-
-        The 'parse' command was renamed to 'overview' for better discoverability.
-        This is a deliberate breaking change. Callers using 'parse' must update
-        to use 'overview' instead.
-        """
-        import pytest
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError) as exc_info:
-            MarkdownAction(command="parse", file="test.md")
-
-        error = str(exc_info.value)
-        assert "parse" in error.lower() or "literal" in error.lower()
-
-    def test_overview_replaces_parse(self):
-        """Verify 'overview' is the replacement for deprecated 'parse' command."""
-        action = MarkdownAction(command="overview", file="test.md")
-        assert action.command == "overview"


### PR DESCRIPTION
## Summary

The `parse` command name was too technical and didn't clearly convey its purpose to agents. This PR renames it to `overview` which better describes what it does: provides a structural overview of the document for navigation.

## Problem

When an agent encounters the markdown document tool, the `parse` command sounds like an internal implementation detail rather than a user-facing action. Agents are less likely to use it when they want to:
- Get an overview of a document before editing
- Navigate to a specific section
- Understand how the document is organized
- Find where a section is located (line numbers)

## Solution

1. **Renamed the command** from `parse` to `overview`

2. **Improved the command description** to guide agent behavior:
   ```
   'overview' shows document structure with section titles, numbers, and line ranges - 
   use this FIRST when working with an unfamiliar document to understand its organization
   ```

3. **Added RECOMMENDED WORKFLOW** note to the tool description:
   ```
   RECOMMENDED WORKFLOW: Start with 'overview' to see the document's hierarchical
   structure and locate sections by number or title before making structural edits.
   ```

4. **Updated visualization text** from "Parsed X sections" to "Document has X sections" for clearer feedback

## Changes

- `src/tools/markdown/tool.py`: Renamed command, improved descriptions, updated method names
- `tests/tools/markdown/test_tool.py`: Updated all tests for the new command name
- `doc/design/markdown-tool.md`: Updated design documentation

## Testing

All 456 tests pass.