### PR TITLE
feat: Add reasoning-focused visualizer with verbosity control

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,3 +122,9 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "ruff>=0.14.10",
+]

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -454,6 +454,7 @@ def run_task(
     task: str,
     workspace: Path,
     llm: LLM | None = None,
+    verbosity: Verbosity = Verbosity.NORMAL,
 ) -> int:
     """Run a prompt-driven task using a simple agent.
 
@@ -465,6 +466,7 @@ def run_task(
         workspace: Path to the workspace (git repository root)
         llm: Optional LLM instance (defaults to get_llm() if not provided).
             Useful for testing with a mock LLM.
+        verbosity: Output verbosity level (quiet, normal, verbose)
 
     Returns:
         Exit code (0 for success, 1 for error/stuck)
@@ -503,11 +505,12 @@ def run_task(
     console.print("[bold cyan]Starting task execution...[/]")
     console.print()
 
-    # Create conversation with visualizer and persistence
+    # Create conversation with verbosity-appropriate visualizer and persistence
+    visualizer = get_visualizer(verbosity, name="TaskRunner")
     conversation = Conversation(
         agent=agent,
         workspace=workspace,
-        visualizer=DelegationVisualizer(name="TaskRunner"),
+        visualizer=visualizer,
         persistence_dir=CONVERSATIONS_DIR,
     )
 
@@ -541,6 +544,23 @@ def run_task(
         console.print()
         console.print(f"[yellow]Task ended with unexpected status: {status.value}[/]")
         return 1
+
+
+def _resolve_verbosity(verbosity_arg: str | None, background: bool) -> Verbosity:
+    """Resolve verbosity level based on explicit arg and background mode.
+
+    Args:
+        verbosity_arg: Explicit --verbosity value, or None if not specified
+        background: Whether --background was specified
+
+    Returns:
+        Resolved Verbosity level: quiet for background (unless overridden),
+        normal otherwise
+    """
+    if verbosity_arg is not None:
+        return Verbosity(verbosity_arg)
+    # Default: quiet for background, normal for foreground
+    return Verbosity.QUIET if background else Verbosity.NORMAL
 
 
 def _filter_background_args(argv: list[str]) -> list[str]:
@@ -806,10 +826,11 @@ Configuration:
         "--verbosity",
         "-v",
         choices=["quiet", "normal", "verbose"],
-        default="normal",
+        default=None,  # None means: use quiet for background, normal otherwise
         help=(
             "Output verbosity: quiet (summaries only), "
-            "normal (reasoning + summaries), verbose (all details) (default: normal)"
+            "normal (reasoning + summaries), verbose (all details). "
+            "Default: quiet for --background, normal otherwise"
         ),
     )
     implement_parser.add_argument(
@@ -895,6 +916,17 @@ Configuration:
         help="Phase to run: auto (detect), self-review, or respond (default: auto)",
     )
     refine_parser.add_argument(
+        "--verbosity",
+        "-v",
+        choices=["quiet", "normal", "verbose"],
+        default=None,  # None means: use quiet for background, normal otherwise
+        help=(
+            "Output verbosity: quiet (summaries only), "
+            "normal (reasoning + summaries), verbose (all details). "
+            "Default: quiet for --background, normal otherwise"
+        ),
+    )
+    refine_parser.add_argument(
         "--background",
         "-b",
         action="store_true",
@@ -931,6 +963,17 @@ Configuration:
         type=Path,
         default=None,
         help="Workspace directory (defaults to current git root)",
+    )
+    run_parser.add_argument(
+        "--verbosity",
+        "-v",
+        choices=["quiet", "normal", "verbose"],
+        default=None,  # None means: use quiet for background, normal otherwise
+        help=(
+            "Output verbosity: quiet (summaries only), "
+            "normal (reasoning + summaries), verbose (all details). "
+            "Default: quiet for --background, normal otherwise"
+        ),
     )
     run_parser.add_argument(
         "--background",
@@ -1422,6 +1465,9 @@ Configuration:
     if args.command == "refine":
         workspace = args.workspace.resolve() if args.workspace else find_git_root(Path.cwd())
 
+        # Resolve verbosity: quiet for background unless explicitly set
+        verbosity = _resolve_verbosity(args.verbosity, args.background)
+
         # Handle background mode
         if args.background:
             from src.jobs import spawn_lxa_command
@@ -1429,6 +1475,10 @@ Configuration:
             # Filter out --background and --job-name, keep everything else
             args_to_use = argv if argv is not None else sys.argv[1:]
             cmd = _filter_background_args(args_to_use)
+
+            # Add --verbosity to the command if not already present
+            if "--verbosity" not in cmd and "-v" not in cmd:
+                cmd = cmd + ["--verbosity", verbosity.value]
 
             # Rewrite paths to be relative for isolated workspace
             cmd, path_warnings = _rewrite_paths_for_background(cmd, workspace)
@@ -1442,6 +1492,7 @@ Configuration:
             console.print(f"Started job [cyan]{job.id}[/], logs at {job.log_path}")
             return 0
 
+        # TODO: pass verbosity to run_refine when it supports it
         return run_refine(
             pr_url=args.pr_url,
             workspace=workspace,
@@ -1479,6 +1530,9 @@ Configuration:
                 console.print(f"[red]Error:[/] Task file is empty: {task_file}")
                 return 1
 
+        # Resolve verbosity: quiet for background unless explicitly set
+        verbosity = _resolve_verbosity(args.verbosity, args.background)
+
         # Handle background mode
         if args.background:
             from src.jobs import spawn_lxa_command
@@ -1486,6 +1540,10 @@ Configuration:
             # Filter out --background and --job-name, keep everything else
             args_to_use = argv if argv is not None else sys.argv[1:]
             cmd = _filter_background_args(args_to_use)
+
+            # Add --verbosity to the command if not already present
+            if "--verbosity" not in cmd and "-v" not in cmd:
+                cmd = cmd + ["--verbosity", verbosity.value]
 
             # Rewrite paths to be relative for isolated workspace
             cmd, path_warnings = _rewrite_paths_for_background(cmd, workspace)
@@ -1499,7 +1557,7 @@ Configuration:
             console.print(f"Started job [cyan]{job.id}[/], logs at {job.log_path}")
             return 0
 
-        return run_task(task=task, workspace=workspace)
+        return run_task(task=task, workspace=workspace, verbosity=verbosity)
 
     # Handle implement command with config-based path resolution
     # When design_doc is provided, derive workspace from it (backward compatible)
@@ -1516,8 +1574,8 @@ Configuration:
         design_path = config.get_design_path(keep_design=args.keep_design)
         design_doc = workspace / design_path
 
-    # Parse verbosity level
-    verbosity = Verbosity(args.verbosity)
+    # Resolve verbosity: quiet for background unless explicitly set
+    verbosity = _resolve_verbosity(args.verbosity, args.background)
 
     # Handle background mode
     if args.background:
@@ -1526,6 +1584,10 @@ Configuration:
         # Filter out --background and --job-name, keep everything else
         args_to_use = argv if argv is not None else sys.argv[1:]
         cmd = _filter_background_args(args_to_use)
+
+        # Add --verbosity to the command if not already present
+        if "--verbosity" not in cmd and "-v" not in cmd:
+            cmd = cmd + ["--verbosity", verbosity.value]
 
         # Rewrite paths to be relative for isolated workspace
         cmd, path_warnings = _rewrite_paths_for_background(cmd, workspace)

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -417,6 +417,7 @@ def run_ralph_loop(
     max_iterations: int = 20,
     refinement_config: RefinementConfig | None = None,
     verbosity: Verbosity = Verbosity.NORMAL,
+    show_timestamps: bool = False,
 ) -> int:
     """Run the Ralph Loop for continuous autonomous execution.
 
@@ -426,6 +427,7 @@ def run_ralph_loop(
         max_iterations: Maximum iterations before stopping
         refinement_config: Configuration for code review refinement loop
         verbosity: Output verbosity level (quiet, normal, verbose)
+        show_timestamps: If True, prefix output lines with timestamps
 
     Returns:
         Exit code (0 for success, 1 for failure)
@@ -447,6 +449,7 @@ def run_ralph_loop(
         max_iterations=max_iterations,
         refinement_config=refinement_config,
         verbosity=verbosity,
+        show_timestamps=show_timestamps,
     )
 
     loop_result = runner.run()
@@ -926,22 +929,6 @@ Configuration:
         choices=["auto", "self-review", "respond"],
         default="auto",
         help="Phase to run: auto (detect), self-review, or respond (default: auto)",
-    )
-    refine_parser.add_argument(
-        "--verbosity",
-        "-v",
-        choices=["quiet", "normal", "verbose"],
-        default=None,  # None means: use quiet for background, normal otherwise
-        help=(
-            "Output verbosity: quiet (summaries only), "
-            "normal (reasoning + summaries), verbose (all details). "
-            "Default: quiet for --background, normal otherwise"
-        ),
-    )
-    refine_parser.add_argument(
-        "--timestamps",
-        action="store_true",
-        help="Prefix output lines with timestamps (auto-enabled for --background)",
     )
     refine_parser.add_argument(
         "--background",
@@ -1487,9 +1474,6 @@ Configuration:
     if args.command == "refine":
         workspace = args.workspace.resolve() if args.workspace else find_git_root(Path.cwd())
 
-        # Resolve verbosity: quiet for background unless explicitly set
-        verbosity = _resolve_verbosity(args.verbosity, args.background)
-
         # Handle background mode
         if args.background:
             from src.jobs import spawn_lxa_command
@@ -1497,14 +1481,6 @@ Configuration:
             # Filter out --background and --job-name, keep everything else
             args_to_use = argv if argv is not None else sys.argv[1:]
             cmd = _filter_background_args(args_to_use)
-
-            # Add --verbosity to the command if not already present
-            if "--verbosity" not in cmd and "-v" not in cmd:
-                cmd = cmd + ["--verbosity", verbosity.value]
-
-            # Add --timestamps for background jobs (unless user already specified)
-            if "--timestamps" not in cmd:
-                cmd = cmd + ["--timestamps"]
 
             # Rewrite paths to be relative for isolated workspace
             cmd, path_warnings = _rewrite_paths_for_background(cmd, workspace)
@@ -1518,7 +1494,6 @@ Configuration:
             console.print(f"Started job [cyan]{job.id}[/], logs at {job.log_path}")
             return 0
 
-        # TODO: pass verbosity and timestamps to run_refine when it supports it
         return run_refine(
             pr_url=args.pr_url,
             workspace=workspace,
@@ -1654,7 +1629,7 @@ Configuration:
                 max_iterations=args.max_refine_iterations,
             ),
             verbosity=verbosity,
-            # TODO: pass show_timestamps when run_ralph_loop supports it
+            show_timestamps=args.timestamps,
         )
     else:
         return run_orchestrator(

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -343,6 +343,8 @@ def run_refine(
     min_iterations: int = 1,
     max_iterations: int = 5,
     phase: str = "auto",
+    verbosity: Verbosity = Verbosity.NORMAL,
+    show_timestamps: bool = False,
 ) -> int:
     """Run the refinement loop on an existing PR.
 
@@ -354,6 +356,8 @@ def run_refine(
         min_iterations: Minimum review iterations before accepting "acceptable"
         max_iterations: Maximum refinement iterations
         phase: Which phase to run: "auto", "self-review", or "respond"
+        verbosity: Output verbosity level (quiet, normal, verbose)
+        show_timestamps: If True, prefix output lines with timestamps
 
     Returns:
         Exit code (0 for success, 1 for failure)
@@ -404,6 +408,8 @@ def run_refine(
         repo_slug=repo_slug,
         refinement_config=refinement_config,
         phase=phase_enum,
+        verbosity=verbosity,
+        show_timestamps=show_timestamps,
     )
 
     result = runner.run()
@@ -571,6 +577,33 @@ def _resolve_verbosity(verbosity_arg: str | None, background: bool) -> Verbosity
         return Verbosity(verbosity_arg)
     # Default: quiet for background, normal for foreground
     return Verbosity.QUIET if background else Verbosity.NORMAL
+
+
+def _add_verbosity_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add --verbosity and --timestamps arguments to a parser.
+
+    This is a DRY helper to ensure consistent verbosity/timestamp options
+    across all commands that run agent conversations.
+
+    Args:
+        parser: The argparse parser or subparser to add arguments to
+    """
+    parser.add_argument(
+        "--verbosity",
+        "-v",
+        choices=["quiet", "normal", "verbose"],
+        default=None,  # None means: use quiet for background, normal otherwise
+        help=(
+            "Output verbosity: quiet (summaries only), "
+            "normal (reasoning + summaries), verbose (all details). "
+            "Default: quiet for --background, normal otherwise"
+        ),
+    )
+    parser.add_argument(
+        "--timestamps",
+        action="store_true",
+        help="Prefix output lines with timestamps (auto-enabled for --background)",
+    )
 
 
 def _filter_background_args(argv: list[str]) -> list[str]:
@@ -832,22 +865,7 @@ Configuration:
         default=5,
         help="Maximum refinement iterations (default: 5)",
     )
-    implement_parser.add_argument(
-        "--verbosity",
-        "-v",
-        choices=["quiet", "normal", "verbose"],
-        default=None,  # None means: use quiet for background, normal otherwise
-        help=(
-            "Output verbosity: quiet (summaries only), "
-            "normal (reasoning + summaries), verbose (all details). "
-            "Default: quiet for --background, normal otherwise"
-        ),
-    )
-    implement_parser.add_argument(
-        "--timestamps",
-        action="store_true",
-        help="Prefix output lines with timestamps (auto-enabled for --background)",
-    )
+    _add_verbosity_arguments(implement_parser)
     implement_parser.add_argument(
         "--background",
         "-b",
@@ -930,6 +948,7 @@ Configuration:
         default="auto",
         help="Phase to run: auto (detect), self-review, or respond (default: auto)",
     )
+    _add_verbosity_arguments(refine_parser)
     refine_parser.add_argument(
         "--background",
         "-b",
@@ -968,22 +987,7 @@ Configuration:
         default=None,
         help="Workspace directory (defaults to current git root)",
     )
-    run_parser.add_argument(
-        "--verbosity",
-        "-v",
-        choices=["quiet", "normal", "verbose"],
-        default=None,  # None means: use quiet for background, normal otherwise
-        help=(
-            "Output verbosity: quiet (summaries only), "
-            "normal (reasoning + summaries), verbose (all details). "
-            "Default: quiet for --background, normal otherwise"
-        ),
-    )
-    run_parser.add_argument(
-        "--timestamps",
-        action="store_true",
-        help="Prefix output lines with timestamps (auto-enabled for --background)",
-    )
+    _add_verbosity_arguments(run_parser)
     run_parser.add_argument(
         "--background",
         "-b",
@@ -1474,6 +1478,9 @@ Configuration:
     if args.command == "refine":
         workspace = args.workspace.resolve() if args.workspace else find_git_root(Path.cwd())
 
+        # Resolve verbosity: quiet for background unless explicitly set
+        verbosity = _resolve_verbosity(args.verbosity, args.background)
+
         # Handle background mode
         if args.background:
             from src.jobs import spawn_lxa_command
@@ -1481,6 +1488,14 @@ Configuration:
             # Filter out --background and --job-name, keep everything else
             args_to_use = argv if argv is not None else sys.argv[1:]
             cmd = _filter_background_args(args_to_use)
+
+            # Add --verbosity to the command if not already present
+            if "--verbosity" not in cmd and "-v" not in cmd:
+                cmd = cmd + ["--verbosity", verbosity.value]
+
+            # Add --timestamps for background jobs (unless user already specified)
+            if "--timestamps" not in cmd:
+                cmd = cmd + ["--timestamps"]
 
             # Rewrite paths to be relative for isolated workspace
             cmd, path_warnings = _rewrite_paths_for_background(cmd, workspace)
@@ -1502,6 +1517,8 @@ Configuration:
             min_iterations=args.min_iterations,
             max_iterations=args.max_iterations,
             phase=args.phase,
+            verbosity=verbosity,
+            show_timestamps=args.timestamps,
         )
 
     # Handle run command - prompt-driven task execution

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -30,7 +30,6 @@ if "LOG_LEVEL" not in os.environ:
 
 from dotenv import load_dotenv
 from openhands.sdk import LLM, Conversation
-from openhands.tools.delegate import DelegationVisualizer
 from rich.console import Console
 from rich.panel import Panel
 
@@ -44,6 +43,7 @@ from src.config import DEFAULT_DESIGN_PATH, load_config
 from src.ralph.runner import DEFAULT_CONVERSATIONS_DIR, RefinementConfig
 from src.skills.reconcile import reconcile_design_doc
 from src.utils.github import parse_pr_url
+from src.visualizers import Verbosity, get_visualizer
 
 # Load environment variables
 load_dotenv()
@@ -149,12 +149,17 @@ def prepare_execution(design_doc: Path, workspace: Path, *, mode_name: str) -> E
     )
 
 
-def run_orchestrator(design_doc: Path, workspace: Path) -> int:
+def run_orchestrator(
+    design_doc: Path,
+    workspace: Path,
+    verbosity: Verbosity = Verbosity.NORMAL,
+) -> int:
     """Run the orchestrator agent.
 
     Args:
         design_doc: Path to the design document
         workspace: Path to the workspace (git repository root)
+        verbosity: Output verbosity level (quiet, normal, verbose)
 
     Returns:
         Exit code (0 for success, 1 for failure)
@@ -175,12 +180,13 @@ def run_orchestrator(design_doc: Path, workspace: Path) -> int:
     console.print("[bold cyan]Starting orchestrator...[/]")
     console.print()
 
-    # Create conversation with visualizer for real-time sub-agent output
-    # and persistence to ~/.openhands/conversations for history
+    # Create conversation with verbosity-appropriate visualizer
+    # Persistence to ~/.openhands/conversations for history
+    visualizer = get_visualizer(verbosity, name="Orchestrator")
     conversation = Conversation(
         agent=agent,
         workspace=ctx.workspace,
-        visualizer=DelegationVisualizer(name="Orchestrator"),
+        visualizer=visualizer,
         persistence_dir=CONVERSATIONS_DIR,
     )
 
@@ -353,6 +359,7 @@ def run_ralph_loop(
     *,
     max_iterations: int = 20,
     refinement_config: RefinementConfig | None = None,
+    verbosity: Verbosity = Verbosity.NORMAL,
 ) -> int:
     """Run the Ralph Loop for continuous autonomous execution.
 
@@ -361,6 +368,7 @@ def run_ralph_loop(
         workspace: Path to the workspace (git repository root)
         max_iterations: Maximum iterations before stopping
         refinement_config: Configuration for code review refinement loop
+        verbosity: Output verbosity level (quiet, normal, verbose)
 
     Returns:
         Exit code (0 for success, 1 for failure)
@@ -381,6 +389,7 @@ def run_ralph_loop(
         platform=ctx.platform,
         max_iterations=max_iterations,
         refinement_config=refinement_config,
+        verbosity=verbosity,
     )
 
     loop_result = runner.run()
@@ -499,6 +508,16 @@ Configuration:
         default=5,
         help="Maximum refinement iterations (default: 5)",
     )
+    implement_parser.add_argument(
+        "--verbosity",
+        "-v",
+        choices=["quiet", "normal", "verbose"],
+        default="normal",
+        help=(
+            "Output verbosity: quiet (summaries only), "
+            "normal (reasoning + summaries), verbose (all details) (default: normal)"
+        ),
+    )
 
     # Reconcile subcommand
     reconcile_parser = subparsers.add_parser(
@@ -606,6 +625,9 @@ Configuration:
         design_path = config.get_design_path(keep_design=args.keep_design)
         design_doc = workspace / design_path
 
+    # Parse verbosity level
+    verbosity = Verbosity(args.verbosity)
+
     # Run in loop mode or single execution
     if args.loop:
         return run_ralph_loop(
@@ -619,9 +641,10 @@ Configuration:
                 min_iterations=args.min_iterations,
                 max_iterations=args.max_refine_iterations,
             ),
+            verbosity=verbosity,
         )
     else:
-        return run_orchestrator(design_doc, workspace)
+        return run_orchestrator(design_doc, workspace, verbosity=verbosity)
 
 
 def find_git_root(start_path: Path) -> Path:

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -53,7 +53,6 @@ from openhands.sdk.subagent import (  # pyright: ignore[reportMissingImports]
 from openhands.tools import (  # pyright: ignore[reportAttributeAccessIssue]
     register_builtins_agents,
 )
-from openhands.tools.delegate import DelegationVisualizer  # noqa: F401
 from rich.console import Console
 from rich.panel import Panel
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -202,6 +202,8 @@ def run_orchestrator(
     design_doc: Path,
     workspace: Path,
     verbosity: Verbosity = Verbosity.NORMAL,
+    *,
+    show_timestamps: bool = False,
 ) -> int:
     """Run the orchestrator agent.
 
@@ -209,6 +211,7 @@ def run_orchestrator(
         design_doc: Path to the design document
         workspace: Path to the workspace (git repository root)
         verbosity: Output verbosity level (quiet, normal, verbose)
+        show_timestamps: If True, prefix output lines with timestamps (for background jobs)
 
     Returns:
         Exit code (0 for success, 1 for failure)
@@ -230,8 +233,9 @@ def run_orchestrator(
     console.print()
 
     # Create conversation with verbosity-appropriate visualizer
+    # Don't pass agent name - it's redundant for the main agent
     # Persistence to ~/.lxa/conversations for history
-    visualizer = get_visualizer(verbosity, name="Orchestrator")
+    visualizer = get_visualizer(verbosity, show_timestamps=show_timestamps)
     conversation = Conversation(
         agent=agent,
         workspace=ctx.workspace,
@@ -455,6 +459,8 @@ def run_task(
     workspace: Path,
     llm: LLM | None = None,
     verbosity: Verbosity = Verbosity.NORMAL,
+    *,
+    show_timestamps: bool = False,
 ) -> int:
     """Run a prompt-driven task using a simple agent.
 
@@ -467,6 +473,7 @@ def run_task(
         llm: Optional LLM instance (defaults to get_llm() if not provided).
             Useful for testing with a mock LLM.
         verbosity: Output verbosity level (quiet, normal, verbose)
+        show_timestamps: If True, prefix output lines with timestamps (for background jobs)
 
     Returns:
         Exit code (0 for success, 1 for error/stuck)
@@ -506,7 +513,8 @@ def run_task(
     console.print()
 
     # Create conversation with verbosity-appropriate visualizer and persistence
-    visualizer = get_visualizer(verbosity, name="TaskRunner")
+    # Don't pass agent name - it's redundant for the main agent
+    visualizer = get_visualizer(verbosity, show_timestamps=show_timestamps)
     conversation = Conversation(
         agent=agent,
         workspace=workspace,
@@ -834,6 +842,11 @@ Configuration:
         ),
     )
     implement_parser.add_argument(
+        "--timestamps",
+        action="store_true",
+        help="Prefix output lines with timestamps (auto-enabled for --background)",
+    )
+    implement_parser.add_argument(
         "--background",
         "-b",
         action="store_true",
@@ -927,6 +940,11 @@ Configuration:
         ),
     )
     refine_parser.add_argument(
+        "--timestamps",
+        action="store_true",
+        help="Prefix output lines with timestamps (auto-enabled for --background)",
+    )
+    refine_parser.add_argument(
         "--background",
         "-b",
         action="store_true",
@@ -974,6 +992,11 @@ Configuration:
             "normal (reasoning + summaries), verbose (all details). "
             "Default: quiet for --background, normal otherwise"
         ),
+    )
+    run_parser.add_argument(
+        "--timestamps",
+        action="store_true",
+        help="Prefix output lines with timestamps (auto-enabled for --background)",
     )
     run_parser.add_argument(
         "--background",
@@ -1480,6 +1503,10 @@ Configuration:
             if "--verbosity" not in cmd and "-v" not in cmd:
                 cmd = cmd + ["--verbosity", verbosity.value]
 
+            # Add --timestamps for background jobs (unless user already specified)
+            if "--timestamps" not in cmd:
+                cmd = cmd + ["--timestamps"]
+
             # Rewrite paths to be relative for isolated workspace
             cmd, path_warnings = _rewrite_paths_for_background(cmd, workspace)
 
@@ -1492,7 +1519,7 @@ Configuration:
             console.print(f"Started job [cyan]{job.id}[/], logs at {job.log_path}")
             return 0
 
-        # TODO: pass verbosity to run_refine when it supports it
+        # TODO: pass verbosity and timestamps to run_refine when it supports it
         return run_refine(
             pr_url=args.pr_url,
             workspace=workspace,
@@ -1545,6 +1572,10 @@ Configuration:
             if "--verbosity" not in cmd and "-v" not in cmd:
                 cmd = cmd + ["--verbosity", verbosity.value]
 
+            # Add --timestamps for background jobs (unless user already specified)
+            if "--timestamps" not in cmd:
+                cmd = cmd + ["--timestamps"]
+
             # Rewrite paths to be relative for isolated workspace
             cmd, path_warnings = _rewrite_paths_for_background(cmd, workspace)
 
@@ -1557,7 +1588,12 @@ Configuration:
             console.print(f"Started job [cyan]{job.id}[/], logs at {job.log_path}")
             return 0
 
-        return run_task(task=task, workspace=workspace, verbosity=verbosity)
+        return run_task(
+            task=task,
+            workspace=workspace,
+            verbosity=verbosity,
+            show_timestamps=args.timestamps,
+        )
 
     # Handle implement command with config-based path resolution
     # When design_doc is provided, derive workspace from it (backward compatible)
@@ -1589,6 +1625,10 @@ Configuration:
         if "--verbosity" not in cmd and "-v" not in cmd:
             cmd = cmd + ["--verbosity", verbosity.value]
 
+        # Add --timestamps for background jobs (unless user already specified)
+        if "--timestamps" not in cmd:
+            cmd = cmd + ["--timestamps"]
+
         # Rewrite paths to be relative for isolated workspace
         cmd, path_warnings = _rewrite_paths_for_background(cmd, workspace)
 
@@ -1615,9 +1655,15 @@ Configuration:
                 max_iterations=args.max_refine_iterations,
             ),
             verbosity=verbosity,
+            # TODO: pass show_timestamps when run_ralph_loop supports it
         )
     else:
-        return run_orchestrator(design_doc, workspace, verbosity=verbosity)
+        return run_orchestrator(
+            design_doc,
+            workspace,
+            verbosity=verbosity,
+            show_timestamps=args.timestamps,
+        )
 
 
 def find_git_root(start_path: Path) -> Path:

--- a/src/ralph/refine.py
+++ b/src/ralph/refine.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from openhands.sdk import LLM, Agent, AgentContext, Conversation, Tool
 from openhands.sdk.context import Skill
 from openhands.sdk.conversation.base import BaseConversation
-from openhands.tools.delegate import DelegateTool, DelegationVisualizer
+from openhands.tools.delegate import DelegateTool
 from openhands.tools.terminal import TerminalTool
 from rich.console import Console
 from rich.panel import Panel
@@ -37,6 +37,7 @@ from src.ralph.refinement_config import (
     SELF_REVIEW_WORKFLOW,
 )
 from src.ralph.runner import RefinementConfig
+from src.visualizers import Verbosity, get_visualizer
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -252,6 +253,8 @@ class RefineRunner:
         refinement_config: RefinementConfig,
         phase: RefinePhase = RefinePhase.AUTO,
         conversations_dir: str = DEFAULT_CONVERSATIONS_DIR,
+        verbosity: Verbosity = Verbosity.NORMAL,
+        show_timestamps: bool = False,
     ):
         """Initialize the RefineRunner.
 
@@ -263,6 +266,8 @@ class RefineRunner:
             refinement_config: Configuration for refinement behavior
             phase: Which phase to run (auto, self-review, respond)
             conversations_dir: Directory for conversation persistence
+            verbosity: Output verbosity level (quiet, normal, verbose)
+            show_timestamps: If True, prefix output lines with timestamps
         """
         self.llm = llm
         self.workspace = workspace
@@ -272,6 +277,8 @@ class RefineRunner:
         self.refinement_config = refinement_config
         self.phase = phase
         self.conversations_dir = conversations_dir
+        self.verbosity = verbosity
+        self.show_timestamps = show_timestamps
 
     def run(self) -> RefineResult:
         """Run the appropriate refinement phase."""
@@ -418,10 +425,16 @@ Check CI status manually: `gh pr checks {pr_number} --repo {repo_slug}`
             self.refinement_config,
         )
 
+        # Create conversation with verbosity-appropriate visualizer
+        visualizer = get_visualizer(
+            self.verbosity,
+            name=f"SelfReview-PR{self.pr_number}",
+            show_timestamps=self.show_timestamps,
+        )
         conversation = Conversation(
             agent=agent,
             workspace=self.workspace,
-            visualizer=DelegationVisualizer(name=f"SelfReview-PR{self.pr_number}"),
+            visualizer=visualizer,
             persistence_dir=self.conversations_dir,
         )
 
@@ -505,10 +518,16 @@ Output PHASE_COMPLETE when finished.
             thread_count,
         )
 
+        # Create conversation with verbosity-appropriate visualizer
+        visualizer = get_visualizer(
+            self.verbosity,
+            name=f"Respond-PR{self.pr_number}",
+            show_timestamps=self.show_timestamps,
+        )
         conversation = Conversation(
             agent=agent,
             workspace=self.workspace,
-            visualizer=DelegationVisualizer(name=f"Respond-PR{self.pr_number}"),
+            visualizer=visualizer,
             persistence_dir=self.conversations_dir,
         )
 

--- a/src/ralph/runner.py
+++ b/src/ralph/runner.py
@@ -92,6 +92,7 @@ class RalphLoopRunner:
         conversations_dir: str = DEFAULT_CONVERSATIONS_DIR,
         refinement_config: RefinementConfig | None = None,
         verbosity: Verbosity = Verbosity.NORMAL,
+        show_timestamps: bool = False,
     ):
         """Initialize the Ralph Loop runner.
 
@@ -106,6 +107,7 @@ class RalphLoopRunner:
             conversations_dir: Directory for conversation persistence
             refinement_config: Configuration for PR refinement loop
             verbosity: Output verbosity level (quiet, normal, verbose)
+            show_timestamps: If True, prefix output lines with timestamps
         """
         self.llm = llm
         self.design_doc_path = design_doc_path
@@ -117,6 +119,7 @@ class RalphLoopRunner:
         self.conversations_dir = conversations_dir
         self.refinement_config = refinement_config or RefinementConfig()
         self.verbosity = verbosity
+        self.show_timestamps = show_timestamps
 
         self._iteration = 0
         self._consecutive_failures = 0
@@ -275,7 +278,11 @@ class RalphLoopRunner:
             )
 
             # Create conversation with verbosity-appropriate visualizer
-            visualizer = get_visualizer(self.verbosity, name=f"Ralph-{self._iteration}")
+            visualizer = get_visualizer(
+                self.verbosity,
+                name=f"Ralph-{self._iteration}",
+                show_timestamps=self.show_timestamps,
+            )
             conversation = Conversation(
                 agent=agent,
                 workspace=self.workspace,

--- a/src/ralph/runner.py
+++ b/src/ralph/runner.py
@@ -24,6 +24,7 @@ from rich.panel import Panel
 
 from src.agents.orchestrator import GitPlatform, create_orchestrator_agent
 from src.tools.checklist import ChecklistParser
+from src.visualizers import Verbosity, get_visualizer
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -89,6 +90,7 @@ class RalphLoopRunner:
         completion_signal: str = COMPLETION_SIGNAL,
         conversations_dir: str = DEFAULT_CONVERSATIONS_DIR,
         refinement_config: RefinementConfig | None = None,
+        verbosity: Verbosity = Verbosity.NORMAL,
     ):
         """Initialize the Ralph Loop runner.
 
@@ -102,6 +104,7 @@ class RalphLoopRunner:
             completion_signal: String that signals completion in agent output
             conversations_dir: Directory for conversation persistence
             refinement_config: Configuration for PR refinement loop
+            verbosity: Output verbosity level (quiet, normal, verbose)
         """
         self.llm = llm
         self.design_doc_path = design_doc_path
@@ -112,6 +115,7 @@ class RalphLoopRunner:
         self.completion_signal = completion_signal
         self.conversations_dir = conversations_dir
         self.refinement_config = refinement_config or RefinementConfig()
+        self.verbosity = verbosity
 
         self._iteration = 0
         self._consecutive_failures = 0
@@ -257,8 +261,6 @@ class RalphLoopRunner:
         Returns:
             IterationResult with success status and output
         """
-        from openhands.tools.delegate import DelegationVisualizer
-
         try:
             # Build context for this iteration
             context_message = self._build_context_message()
@@ -271,11 +273,12 @@ class RalphLoopRunner:
                 platform=self.platform,
             )
 
-            # Create conversation
+            # Create conversation with verbosity-appropriate visualizer
+            visualizer = get_visualizer(self.verbosity, name=f"Ralph-{self._iteration}")
             conversation = Conversation(
                 agent=agent,
                 workspace=self.workspace,
-                visualizer=DelegationVisualizer(name=f"Ralph-{self._iteration}"),
+                visualizer=visualizer,
                 persistence_dir=self.conversations_dir,
             )
 

--- a/src/visualizers/__init__.py
+++ b/src/visualizers/__init__.py
@@ -1,0 +1,15 @@
+"""Visualizers for lxa agent output."""
+
+from src.visualizers.reasoning_focused import (
+    QuietVisualizer,
+    ReasoningFocusedVisualizer,
+    Verbosity,
+    get_visualizer,
+)
+
+__all__ = [
+    "Verbosity",
+    "ReasoningFocusedVisualizer",
+    "QuietVisualizer",
+    "get_visualizer",
+]

--- a/src/visualizers/reasoning_focused.py
+++ b/src/visualizers/reasoning_focused.py
@@ -5,20 +5,13 @@ hiding verbose technical details by default. This makes it easier to follow
 the agent's reasoning during normal operation.
 
 Example output with ReasoningFocusedVisualizer:
-    → Check the README file contents
+    → Check the README file contents: $ cat README.md
       I need to understand the project structure before implementing changes.
 
-Compared to verbose output:
-    ─── Agent Action ───────────────────────────────────
-    Summary: Check the README file contents
-    Reasoning: I need to understand the project structure...
-    Thought: Let me check the README first to understand...
-    Action: file_editor
-      command: view
-      path: /workspace/project/README.md
-    ─── Observation ────────────────────────────────────
-    # Project Name
-    ...(full file contents)...
+    → Review the main module: Reading src/main.py
+      Let me check how the entry point is structured.
+
+Compared to verbose output which shows full file contents, all parameters, etc.
 """
 
 from __future__ import annotations
@@ -33,12 +26,24 @@ from openhands.sdk.conversation.visualizer.default import (
     DefaultConversationVisualizer,
     build_event_block,
 )
-from openhands.sdk.event import ActionEvent, MessageEvent, ObservationEvent
+from openhands.sdk.event import (
+    ActionEvent,
+    ConversationStateUpdateEvent,
+    MessageEvent,
+    ObservationEvent,
+    SystemPromptEvent,
+)
+from openhands.sdk.event.condenser import Condensation, CondensationRequest
+from openhands.tools.file_editor.definition import FileEditorAction
+from openhands.tools.terminal.definition import TerminalAction
 from rich.console import Console, Group
 from rich.text import Text
 
 if TYPE_CHECKING:
     from openhands.sdk.event.base import Event
+
+# Maximum length for command/path display in titles
+MAX_DETAIL_LENGTH = 60
 
 
 class Verbosity(StrEnum):
@@ -49,11 +54,24 @@ class Verbosity(StrEnum):
     VERBOSE = "verbose"  # Full details (current behavior)
 
 
-def _truncate(text: str, max_length: int = 100) -> str:
-    """Truncate text to max_length, adding ellipsis if needed."""
+def _truncate(text: str, max_length: int = 100, *, from_end: bool = False) -> str:
+    """Truncate text to max_length, adding ellipsis if needed.
+
+    Args:
+        text: Text to truncate.
+        max_length: Maximum length including ellipsis.
+        from_end: If True, keep the end of the text (useful for paths).
+    """
     if len(text) <= max_length:
         return text
+    if from_end:
+        return "..." + text[-(max_length - 3) :]
     return text[: max_length - 3] + "..."
+
+
+def _clean_for_display(text: str) -> str:
+    """Clean text for single-line display (strip, collapse newlines)."""
+    return text.strip().replace("\n", " ")
 
 
 def _extract_summary_from_action(event: ActionEvent) -> str | None:
@@ -80,6 +98,36 @@ def _extract_reasoning(event: ActionEvent) -> str | None:
     thought_text = " ".join([t.text for t in event.thought])
     if thought_text.strip():
         return thought_text.strip()
+
+    return None
+
+
+def _extract_action_detail(event: ActionEvent) -> str | None:
+    """Extract contextual detail from an action (command, path, etc.).
+
+    Returns a formatted string like:
+        "$ ls -la" for terminal commands
+        "Reading /path/to/file" for file_editor view
+        "Editing /path/to/file" for file_editor modifications
+
+    Returns None if no meaningful detail can be extracted.
+    """
+    action = event.action
+    if action is None:
+        return None
+
+    # Terminal actions: show the command
+    if isinstance(action, TerminalAction) and action.command:
+        cmd = _clean_for_display(action.command)
+        cmd = _truncate(cmd, MAX_DETAIL_LENGTH)
+        return f"$ {cmd}"
+
+    # File editor actions: show operation and path
+    if isinstance(action, FileEditorAction) and action.path:
+        op = "Reading" if action.command == "view" else "Editing"
+        # Truncate path from the end to preserve filename
+        path = _truncate(action.path, MAX_DETAIL_LENGTH - len(op) - 1, from_end=True)
+        return f"{op} {path}"
 
     return None
 
@@ -123,7 +171,18 @@ class ReasoningFocusedVisualizer(DefaultConversationVisualizer):
         self._show_observations = show_observations
 
     def _create_event_block(self, event: Event) -> Group | None:
-        """Create a focused event block emphasizing reasoning."""
+        """Create a focused event block emphasizing reasoning.
+
+        Suppresses verbose system events (SystemPrompt, Condensation, etc.)
+        that aren't useful for following agent reasoning.
+        """
+        # Suppress system/infrastructure events - these are noise for reasoning
+        if isinstance(
+            event,
+            SystemPromptEvent | CondensationRequest | Condensation | ConversationStateUpdateEvent,
+        ):
+            return None
+
         if isinstance(event, ActionEvent):
             return self._create_reasoning_block(event)
 
@@ -137,27 +196,43 @@ class ReasoningFocusedVisualizer(DefaultConversationVisualizer):
             # Messages still go through default handling
             return super()._create_event_block(event)
 
-        # Other events use default handling
-        return super()._create_event_block(event)
+        # Other events: suppress by default (fail closed for unknown events)
+        # This prevents verbose output from new event types we haven't considered
+        return None
 
     def _create_reasoning_block(self, event: ActionEvent) -> Group | None:
-        """Create a block focused on the agent's reasoning."""
+        """Create a block focused on the agent's reasoning.
+
+        Format:
+            → Summary: $ command           (for terminal)
+            → Summary: Reading /path       (for file_editor view)
+            → Summary: Editing /path       (for file_editor edit)
+            → Summary                      (for other actions with summary)
+            → [tool_name]                  (fallback when no summary)
+
+        Followed by truncated reasoning/thought content.
+        """
         content = Text()
 
-        # Get summary from tool arguments
+        # Get summary and action detail
         summary = _extract_summary_from_action(event)
+        detail = _extract_action_detail(event)
         tool_name = event.tool_name
 
-        # Build the summary line
+        # Build the summary line with optional detail
+        content.append("→ ", style="bold cyan")
         if summary:
-            content.append("→ ", style="bold cyan")
-            content.append(summary, style="cyan")
-            content.append("\n")
+            content.append(summary, style="bold cyan")
+            if detail:
+                content.append(": ", style="dim")
+                content.append(detail, style="dim")
+        elif detail:
+            # No summary but have detail (e.g., just a command)
+            content.append(detail, style="cyan")
         else:
-            # Fall back to tool name if no summary
-            content.append("→ ", style="bold cyan")
+            # Fall back to tool name if no summary or detail
             content.append(f"[{tool_name}]", style="dim cyan")
-            content.append("\n")
+        content.append("\n")
 
         # Show reasoning/thought content
         reasoning = _extract_reasoning(event)
@@ -222,15 +297,20 @@ class QuietVisualizer(ConversationVisualizerBase):
         self._name = name
 
     def on_event(self, event: Event) -> None:
-        """Display only action summaries."""
+        """Display only action summaries with contextual details."""
         if not isinstance(event, ActionEvent):
             return
 
         summary = _extract_summary_from_action(event)
+        detail = _extract_action_detail(event)
         prefix = f"[dim]{self._name}:[/] " if self._name else ""
 
-        if summary:
+        if summary and detail:
+            self._console.print(f"{prefix}{summary}[dim]: {detail}[/]")
+        elif summary:
             self._console.print(f"{prefix}{summary}")
+        elif detail:
+            self._console.print(f"{prefix}{detail}")
         else:
             # Fall back to tool name
             self._console.print(f"{prefix}[dim][{event.tool_name}][/]")

--- a/src/visualizers/reasoning_focused.py
+++ b/src/visualizers/reasoning_focused.py
@@ -11,12 +11,18 @@ Example output with ReasoningFocusedVisualizer:
     → Review the main module: Reading src/main.py
       Let me check how the entry point is structured.
 
+Example output with QuietVisualizer (timestamps enabled for background jobs):
+    [14:27:23] Clone the repository: $ git clone https://github.com/...
+    [14:27:25] Check project structure: $ ls -la
+    [14:27:26] ✓ Task completed successfully
+
 Compared to verbose output which shows full file contents, all parameters, etc.
 """
 
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
@@ -34,6 +40,7 @@ from openhands.sdk.event import (
     SystemPromptEvent,
 )
 from openhands.sdk.event.condenser import Condensation, CondensationRequest
+from openhands.sdk.tool.builtins.finish import FinishAction
 from openhands.tools.file_editor.definition import FileEditorAction
 from openhands.tools.terminal.definition import TerminalAction
 from rich.console import Console, Group
@@ -210,6 +217,9 @@ class ReasoningFocusedVisualizer(DefaultConversationVisualizer):
             → Summary                      (for other actions with summary)
             → [tool_name]                  (fallback when no summary)
 
+        For sub-agents (delegation), prefix with agent name in brackets:
+            [Research Agent] → Summary: $ command
+
         Followed by truncated reasoning/thought content.
         """
         content = Text()
@@ -218,6 +228,10 @@ class ReasoningFocusedVisualizer(DefaultConversationVisualizer):
         summary = _extract_summary_from_action(event)
         detail = _extract_action_detail(event)
         tool_name = event.tool_name
+
+        # For sub-agents, prefix with agent name in brackets
+        if self._name:
+            content.append(f"[{self._name}] ", style="dim cyan")
 
         # Build the summary line with optional detail
         content.append("→ ", style="bold cyan")
@@ -246,11 +260,10 @@ class ReasoningFocusedVisualizer(DefaultConversationVisualizer):
         if not content.plain.strip():
             return None
 
-        # Build the block with minimal decoration
-        agent_name = self._name or "Agent"
+        # Build the block without title (content already has agent prefix if needed)
         return build_event_block(
             content=content,
-            title=agent_name,
+            title="",
             title_color=_ACTION_COLOR,
             subtitle=self._format_metrics_subtitle(),
         )
@@ -278,53 +291,125 @@ class ReasoningFocusedVisualizer(DefaultConversationVisualizer):
 
 
 class QuietVisualizer(ConversationVisualizerBase):
-    """Minimal visualizer that shows only action summaries.
+    """Minimal visualizer that shows action summaries, messages, and finish.
 
     Ideal for CI/CD, headless execution, or log-focused monitoring.
+    Shows timestamps when enabled (useful for background job logs).
     """
 
     _console: Console
     _name: str | None
+    _show_timestamps: bool
 
-    def __init__(self, name: str | None = None):
+    def __init__(self, name: str | None = None, *, show_timestamps: bool = False):
         """Initialize the quiet visualizer.
 
         Args:
-            name: Agent name to prefix output with.
+            name: Agent name to prefix output with (for sub-agents only).
+            show_timestamps: If True, prefix each line with [HH:MM:SS] timestamp.
         """
         super().__init__()
         self._console = Console()
         self._name = name
+        self._show_timestamps = show_timestamps
+
+    def _format_line(self, message: str, *, style: str | None = None) -> str:
+        """Format a line with optional timestamp and agent prefix.
+
+        Args:
+            message: The message to format.
+            style: Optional Rich style to apply to the message.
+
+        Returns:
+            Formatted string ready for console.print().
+        """
+        parts = []
+
+        # Timestamp prefix for background jobs
+        if self._show_timestamps:
+            ts = datetime.now().strftime("%H:%M:%S")
+            parts.append(f"[dim]\\[{ts}][/dim]")
+
+        # Agent name prefix for sub-agents (delegation)
+        if self._name:
+            parts.append(f"[dim]\\[{self._name}][/dim]")
+
+        # The message itself
+        if style:
+            parts.append(f"[{style}]{message}[/{style}]")
+        else:
+            parts.append(message)
+
+        return " ".join(parts)
 
     def on_event(self, event: Event) -> None:
-        """Display only action summaries with contextual details."""
-        if not isinstance(event, ActionEvent):
+        """Display action summaries, user/agent messages, and finish messages."""
+        if isinstance(event, ActionEvent):
+            self._handle_action(event)
+        elif isinstance(event, MessageEvent):
+            self._handle_message(event)
+
+    def _handle_action(self, event: ActionEvent) -> None:
+        """Handle action events - show summary or finish message."""
+        action = event.action
+
+        # Handle finish action specially - show the completion message
+        if isinstance(action, FinishAction) and action.message:
+            self._console.print(self._format_line(f"✓ {action.message}", style="green"))
             return
 
+        # Regular actions: show summary with optional detail
         summary = _extract_summary_from_action(event)
         detail = _extract_action_detail(event)
-        prefix = f"[dim]{self._name}:[/] " if self._name else ""
 
         if summary and detail:
-            self._console.print(f"{prefix}{summary}[dim]: {detail}[/]")
+            line = f"{summary}[dim]: {detail}[/dim]"
         elif summary:
-            self._console.print(f"{prefix}{summary}")
+            line = summary
         elif detail:
-            self._console.print(f"{prefix}{detail}")
+            line = detail
         else:
             # Fall back to tool name
-            self._console.print(f"{prefix}[dim][{event.tool_name}][/]")
+            line = f"[dim]\\[{event.tool_name}][/dim]"
+
+        self._console.print(self._format_line(line))
+
+    def _handle_message(self, event: MessageEvent) -> None:
+        """Handle message events - show user and assistant messages."""
+        if not event.llm_message:
+            return
+
+        content = str(event.visualize).strip()
+        if not content:
+            return
+
+        role = event.llm_message.role
+
+        if role == "user":
+            # User messages: show with "You:" prefix
+            # Truncate long user messages for quiet mode
+            if len(content) > 200:
+                content = content[:197] + "..."
+            self._console.print(self._format_line(f"[bold]You:[/bold] {content}"))
+        elif role == "assistant":
+            # Assistant messages (not from actions): show with "Agent:" prefix
+            if len(content) > 200:
+                content = content[:197] + "..."
+            self._console.print(self._format_line(f"[bold]Agent:[/bold] {content}"))
 
 
 def get_visualizer(
     verbosity: Verbosity | str = Verbosity.NORMAL,
     name: str | None = None,
+    *,
+    show_timestamps: bool = False,
 ) -> ConversationVisualizerBase:
     """Get the appropriate visualizer based on verbosity level.
 
     Args:
         verbosity: The verbosity level (quiet, normal, verbose).
-        name: Agent name to display in output.
+        name: Agent name to display in output (for sub-agents/delegation).
+        show_timestamps: If True, prefix lines with timestamps (for background jobs).
 
     Returns:
         A visualizer configured for the requested verbosity level.
@@ -334,7 +419,7 @@ def get_visualizer(
         verbosity = Verbosity(verbosity)
 
     if verbosity == Verbosity.QUIET:
-        return QuietVisualizer(name=name)
+        return QuietVisualizer(name=name, show_timestamps=show_timestamps)
     elif verbosity == Verbosity.VERBOSE:
         # Import here to avoid circular dependency
         from openhands.tools.delegate import DelegationVisualizer

--- a/src/visualizers/reasoning_focused.py
+++ b/src/visualizers/reasoning_focused.py
@@ -191,6 +191,9 @@ class ReasoningFocusedVisualizer(DefaultConversationVisualizer):
             return None
 
         if isinstance(event, ActionEvent):
+            # Handle finish action specially - show completion message prominently
+            if isinstance(event.action, FinishAction) and event.action.message:
+                return self._create_finish_block(event.action.message)
             return self._create_reasoning_block(event)
 
         if isinstance(event, ObservationEvent):
@@ -287,6 +290,19 @@ class ReasoningFocusedVisualizer(DefaultConversationVisualizer):
             content=content,
             title="Result",
             title_color="yellow",
+        )
+
+    def _create_finish_block(self, message: str) -> Group:
+        """Create a block for the finish action completion message."""
+        content = Text()
+        content.append("✓ ", style="bold green")
+        content.append(message, style="green")
+        content.append("\n")
+
+        return build_event_block(
+            content=content,
+            title="",
+            title_color="green",
         )
 
 

--- a/src/visualizers/reasoning_focused.py
+++ b/src/visualizers/reasoning_focused.py
@@ -402,16 +402,16 @@ class QuietVisualizer(ConversationVisualizerBase):
         role = event.llm_message.role
 
         if role == "user":
-            # User messages: show with "You:" prefix
+            # User messages: show with "Prompt:" prefix
             # Truncate long user messages for quiet mode
             if len(content) > 200:
                 content = content[:197] + "..."
-            self._console.print(self._format_line(f"[bold]You:[/bold] {content}"))
+            self._console.print(self._format_line(f"[bold]Prompt:[/bold] {content}"))
         elif role == "assistant":
-            # Assistant messages (not from actions): show with "Agent:" prefix
+            # Assistant messages (not from actions): show with "OpenHands:" prefix
             if len(content) > 200:
                 content = content[:197] + "..."
-            self._console.print(self._format_line(f"[bold]Agent:[/bold] {content}"))
+            self._console.print(self._format_line(f"[bold]OpenHands:[/bold] {content}"))
 
 
 def get_visualizer(

--- a/src/visualizers/reasoning_focused.py
+++ b/src/visualizers/reasoning_focused.py
@@ -1,0 +1,264 @@
+"""Reasoning-focused visualizer that emphasizes agent thinking over technical details.
+
+This module provides visualizers that show what the agent is thinking and why,
+hiding verbose technical details by default. This makes it easier to follow
+the agent's reasoning during normal operation.
+
+Example output with ReasoningFocusedVisualizer:
+    → Check the README file contents
+      I need to understand the project structure before implementing changes.
+
+Compared to verbose output:
+    ─── Agent Action ───────────────────────────────────
+    Summary: Check the README file contents
+    Reasoning: I need to understand the project structure...
+    Thought: Let me check the README first to understand...
+    Action: file_editor
+      command: view
+      path: /workspace/project/README.md
+    ─── Observation ────────────────────────────────────
+    # Project Name
+    ...(full file contents)...
+"""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from openhands.sdk.conversation.visualizer.base import ConversationVisualizerBase
+from openhands.sdk.conversation.visualizer.default import (
+    _ACTION_COLOR,
+    DefaultConversationVisualizer,
+    build_event_block,
+)
+from openhands.sdk.event import ActionEvent, MessageEvent, ObservationEvent
+from rich.console import Console, Group
+from rich.text import Text
+
+if TYPE_CHECKING:
+    from openhands.sdk.event.base import Event
+
+
+class Verbosity(str, Enum):
+    """Verbosity levels for agent output."""
+
+    QUIET = "quiet"  # Summaries only
+    NORMAL = "normal"  # Reasoning + summaries (default)
+    VERBOSE = "verbose"  # Full details (current behavior)
+
+
+def _truncate(text: str, max_length: int = 100) -> str:
+    """Truncate text to max_length, adding ellipsis if needed."""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3] + "..."
+
+
+def _extract_summary_from_action(event: ActionEvent) -> str | None:
+    """Extract the summary from an ActionEvent's tool call arguments.
+
+    Many tools (terminal, file_editor, browser actions, etc.) accept a 'summary'
+    parameter that describes what the action does in a human-readable way.
+    """
+    try:
+        args = json.loads(event.tool_call.arguments)
+        return args.get("summary")
+    except (json.JSONDecodeError, AttributeError):
+        return None
+
+
+def _extract_reasoning(event: ActionEvent) -> str | None:
+    """Extract reasoning content from an ActionEvent.
+
+    Prefers reasoning_content (from reasoning models), falls back to thought text.
+    """
+    if event.reasoning_content:
+        return event.reasoning_content.strip()
+
+    thought_text = " ".join([t.text for t in event.thought])
+    if thought_text.strip():
+        return thought_text.strip()
+
+    return None
+
+
+class ReasoningFocusedVisualizer(DefaultConversationVisualizer):
+    """Visualizer that emphasizes agent reasoning over technical details.
+
+    Shows:
+    - Summary prominently (from tool call 'summary' parameter)
+    - Reasoning content (why the agent is doing this)
+
+    Hides by default:
+    - Full action parameters
+    - Observation outputs (file contents, command results)
+    - Technical tool names and arguments
+    """
+
+    _name: str | None
+    _show_observations: bool
+
+    def __init__(
+        self,
+        name: str | None = None,
+        show_observations: bool = False,
+        highlight_regex: dict[str, str] | None = None,
+        skip_user_messages: bool = False,
+    ):
+        """Initialize the reasoning-focused visualizer.
+
+        Args:
+            name: Agent name to display in output.
+            show_observations: If True, show observation outputs (for debugging).
+            highlight_regex: Patterns to highlight in output.
+            skip_user_messages: If True, skip displaying user messages.
+        """
+        super().__init__(
+            highlight_regex=highlight_regex,
+            skip_user_messages=skip_user_messages,
+        )
+        self._name = name
+        self._show_observations = show_observations
+
+    def _create_event_block(self, event: Event) -> Group | None:
+        """Create a focused event block emphasizing reasoning."""
+        if isinstance(event, ActionEvent):
+            return self._create_reasoning_block(event)
+
+        if isinstance(event, ObservationEvent):
+            if not self._show_observations:
+                return None
+            # Show truncated observation summary
+            return self._create_observation_summary(event)
+
+        if isinstance(event, MessageEvent):
+            # Messages still go through default handling
+            return super()._create_event_block(event)
+
+        # Other events use default handling
+        return super()._create_event_block(event)
+
+    def _create_reasoning_block(self, event: ActionEvent) -> Group | None:
+        """Create a block focused on the agent's reasoning."""
+        content = Text()
+
+        # Get summary from tool arguments
+        summary = _extract_summary_from_action(event)
+        tool_name = event.tool_name
+
+        # Build the summary line
+        if summary:
+            content.append("→ ", style="bold cyan")
+            content.append(summary, style="cyan")
+            content.append("\n")
+        else:
+            # Fall back to tool name if no summary
+            content.append("→ ", style="bold cyan")
+            content.append(f"[{tool_name}]", style="dim cyan")
+            content.append("\n")
+
+        # Show reasoning/thought content
+        reasoning = _extract_reasoning(event)
+        if reasoning:
+            # Indent and truncate reasoning for readability
+            truncated = _truncate(reasoning, max_length=200)
+            content.append("  ", style="dim")
+            content.append(truncated, style="dim")
+            content.append("\n")
+
+        if not content.plain.strip():
+            return None
+
+        # Build the block with minimal decoration
+        agent_name = self._name or "Agent"
+        return build_event_block(
+            content=content,
+            title=agent_name,
+            title_color=_ACTION_COLOR,
+            subtitle=self._format_metrics_subtitle(),
+        )
+
+    def _create_observation_summary(self, event: ObservationEvent) -> Group | None:
+        """Create a brief observation summary (when show_observations is True)."""
+        content = event.visualize
+        if not content.plain.strip():
+            return None
+
+        # Truncate long observations
+        plain_text = content.plain
+        if len(plain_text) > 300:
+            truncated = Text()
+            truncated.append(plain_text[:300], style="dim")
+            truncated.append("...", style="dim italic")
+            truncated.append(f" ({len(plain_text)} chars)", style="dim")
+            content = truncated
+
+        return build_event_block(
+            content=content,
+            title="Result",
+            title_color="yellow",
+        )
+
+
+class QuietVisualizer(ConversationVisualizerBase):
+    """Minimal visualizer that shows only action summaries.
+
+    Ideal for CI/CD, headless execution, or log-focused monitoring.
+    """
+
+    _console: Console
+    _name: str | None
+
+    def __init__(self, name: str | None = None):
+        """Initialize the quiet visualizer.
+
+        Args:
+            name: Agent name to prefix output with.
+        """
+        super().__init__()
+        self._console = Console()
+        self._name = name
+
+    def on_event(self, event: Event) -> None:
+        """Display only action summaries."""
+        if not isinstance(event, ActionEvent):
+            return
+
+        summary = _extract_summary_from_action(event)
+        prefix = f"[dim]{self._name}:[/] " if self._name else ""
+
+        if summary:
+            self._console.print(f"{prefix}{summary}")
+        else:
+            # Fall back to tool name
+            self._console.print(f"{prefix}[dim][{event.tool_name}][/]")
+
+
+def get_visualizer(
+    verbosity: Verbosity | str = Verbosity.NORMAL,
+    name: str | None = None,
+) -> ConversationVisualizerBase:
+    """Get the appropriate visualizer based on verbosity level.
+
+    Args:
+        verbosity: The verbosity level (quiet, normal, verbose).
+        name: Agent name to display in output.
+
+    Returns:
+        A visualizer configured for the requested verbosity level.
+    """
+    # Allow string input for CLI convenience
+    if isinstance(verbosity, str):
+        verbosity = Verbosity(verbosity)
+
+    if verbosity == Verbosity.QUIET:
+        return QuietVisualizer(name=name)
+    elif verbosity == Verbosity.VERBOSE:
+        # Import here to avoid circular dependency
+        from openhands.tools.delegate import DelegationVisualizer
+
+        return DelegationVisualizer(name=name)
+    else:  # NORMAL
+        return ReasoningFocusedVisualizer(name=name)

--- a/tests/test_cli_refine.py
+++ b/tests/test_cli_refine.py
@@ -194,9 +194,7 @@ class TestRefineCliArguments:
         assert args.timestamps is True
 
         # Test short flag -v
-        args = parser.parse_args(
-            ["refine", "https://github.com/owner/repo/pull/42", "-v", "quiet"]
-        )
+        args = parser.parse_args(["refine", "https://github.com/owner/repo/pull/42", "-v", "quiet"])
         assert args.verbosity == "quiet"
 
 

--- a/tests/test_cli_refine.py
+++ b/tests/test_cli_refine.py
@@ -163,6 +163,42 @@ class TestRefineCliArguments:
             )
             assert args.allow_merge == allow_merge
 
+    def test_refine_verbosity_arguments(self):
+        """Test that refine command has verbosity arguments."""
+        from src.__main__ import _add_verbosity_arguments
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+
+        refine_parser = subparsers.add_parser("refine")
+        refine_parser.add_argument("pr_url")
+        _add_verbosity_arguments(refine_parser)
+        refine_parser.add_argument("--background", "-b", action="store_true")
+
+        # Test default verbosity (None = auto-detect based on background)
+        args = parser.parse_args(["refine", "https://github.com/owner/repo/pull/42"])
+        assert args.verbosity is None
+        assert args.timestamps is False
+
+        # Test explicit verbosity levels
+        for level in ["quiet", "normal", "verbose"]:
+            args = parser.parse_args(
+                ["refine", "https://github.com/owner/repo/pull/42", "--verbosity", level]
+            )
+            assert args.verbosity == level
+
+        # Test --timestamps flag
+        args = parser.parse_args(
+            ["refine", "https://github.com/owner/repo/pull/42", "--timestamps"]
+        )
+        assert args.timestamps is True
+
+        # Test short flag -v
+        args = parser.parse_args(
+            ["refine", "https://github.com/owner/repo/pull/42", "-v", "quiet"]
+        )
+        assert args.verbosity == "quiet"
+
 
 class TestRefineImports:
     """Test that refine command imports work correctly."""

--- a/tests/visualizers/__init__.py
+++ b/tests/visualizers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for visualizers module."""

--- a/tests/visualizers/test_reasoning_focused.py
+++ b/tests/visualizers/test_reasoning_focused.py
@@ -1,0 +1,189 @@
+"""Tests for the reasoning-focused visualizer."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from openhands.tools.delegate import DelegationVisualizer
+
+from src.visualizers import (
+    QuietVisualizer,
+    ReasoningFocusedVisualizer,
+    Verbosity,
+    get_visualizer,
+)
+from src.visualizers.reasoning_focused import (
+    _extract_reasoning,
+    _extract_summary_from_action,
+    _truncate,
+)
+
+
+class TestVerbosityEnum:
+    """Tests for the Verbosity enum."""
+
+    def test_verbosity_values(self):
+        """Test that verbosity enum has expected values."""
+        assert Verbosity.QUIET.value == "quiet"
+        assert Verbosity.NORMAL.value == "normal"
+        assert Verbosity.VERBOSE.value == "verbose"
+
+    def test_verbosity_from_string(self):
+        """Test creating verbosity from string."""
+        assert Verbosity("quiet") == Verbosity.QUIET
+        assert Verbosity("normal") == Verbosity.NORMAL
+        assert Verbosity("verbose") == Verbosity.VERBOSE
+
+
+class TestGetVisualizer:
+    """Tests for the get_visualizer factory function."""
+
+    def test_quiet_returns_quiet_visualizer(self):
+        """Test that quiet verbosity returns QuietVisualizer."""
+        viz = get_visualizer(Verbosity.QUIET, name="Test")
+        assert isinstance(viz, QuietVisualizer)
+
+    def test_normal_returns_reasoning_focused_visualizer(self):
+        """Test that normal verbosity returns ReasoningFocusedVisualizer."""
+        viz = get_visualizer(Verbosity.NORMAL, name="Test")
+        assert isinstance(viz, ReasoningFocusedVisualizer)
+
+    def test_verbose_returns_delegation_visualizer(self):
+        """Test that verbose verbosity returns DelegationVisualizer."""
+        viz = get_visualizer(Verbosity.VERBOSE, name="Test")
+        assert isinstance(viz, DelegationVisualizer)
+
+    def test_string_input_works(self):
+        """Test that string input is converted to enum."""
+        viz = get_visualizer("quiet", name="Test")
+        assert isinstance(viz, QuietVisualizer)
+
+    def test_name_is_passed_through(self):
+        """Test that name is passed to visualizer."""
+        viz = get_visualizer(Verbosity.NORMAL, name="MyAgent")
+        assert viz._name == "MyAgent"
+
+
+class TestTruncate:
+    """Tests for the _truncate helper function."""
+
+    def test_short_text_unchanged(self):
+        """Test that short text is not truncated."""
+        assert _truncate("hello", 100) == "hello"
+
+    def test_exact_length_unchanged(self):
+        """Test that text at exact length is not truncated."""
+        text = "x" * 100
+        assert _truncate(text, 100) == text
+
+    def test_long_text_truncated(self):
+        """Test that long text is truncated with ellipsis."""
+        text = "x" * 150
+        result = _truncate(text, 100)
+        assert len(result) == 100
+        assert result.endswith("...")
+
+    def test_default_max_length(self):
+        """Test default max_length of 100."""
+        text = "x" * 150
+        result = _truncate(text)
+        assert len(result) == 100
+
+
+class TestExtractSummaryFromAction:
+    """Tests for the _extract_summary_from_action helper function."""
+
+    def test_extracts_summary_from_arguments(self):
+        """Test extracting summary from tool call arguments."""
+        event = MagicMock()
+        event.tool_call.arguments = json.dumps({
+            "command": "ls",
+            "summary": "List files in directory",
+        })
+        assert _extract_summary_from_action(event) == "List files in directory"
+
+    def test_returns_none_when_no_summary(self):
+        """Test that None is returned when no summary in arguments."""
+        event = MagicMock()
+        event.tool_call.arguments = json.dumps({"command": "ls"})
+        assert _extract_summary_from_action(event) is None
+
+    def test_returns_none_on_invalid_json(self):
+        """Test that None is returned for invalid JSON."""
+        event = MagicMock()
+        event.tool_call.arguments = "not json"
+        assert _extract_summary_from_action(event) is None
+
+
+class TestExtractReasoning:
+    """Tests for the _extract_reasoning helper function."""
+
+    def test_prefers_reasoning_content(self):
+        """Test that reasoning_content is preferred over thought."""
+        event = MagicMock()
+        event.reasoning_content = "Deep reasoning here"
+        event.thought = [MagicMock(text="Surface thought")]
+        assert _extract_reasoning(event) == "Deep reasoning here"
+
+    def test_falls_back_to_thought(self):
+        """Test that thought is used when reasoning_content is None."""
+        event = MagicMock()
+        event.reasoning_content = None
+        event.thought = [MagicMock(text="First thought"), MagicMock(text="Second thought")]
+        assert _extract_reasoning(event) == "First thought Second thought"
+
+    def test_returns_none_when_empty(self):
+        """Test that None is returned when both are empty."""
+        event = MagicMock()
+        event.reasoning_content = None
+        event.thought = []
+        assert _extract_reasoning(event) is None
+
+
+class TestReasoningFocusedVisualizer:
+    """Tests for ReasoningFocusedVisualizer."""
+
+    def test_initialization(self):
+        """Test visualizer initialization."""
+        viz = ReasoningFocusedVisualizer(name="Test", show_observations=True)
+        assert viz._name == "Test"
+        assert viz._show_observations is True
+
+    def test_default_show_observations_is_false(self):
+        """Test that show_observations defaults to False."""
+        viz = ReasoningFocusedVisualizer(name="Test")
+        assert viz._show_observations is False
+
+
+class TestQuietVisualizer:
+    """Tests for QuietVisualizer."""
+
+    def test_initialization(self):
+        """Test visualizer initialization."""
+        viz = QuietVisualizer(name="Test")
+        assert viz._name == "Test"
+
+    def test_name_can_be_none(self):
+        """Test that name can be None."""
+        viz = QuietVisualizer()
+        assert viz._name is None
+
+
+class TestCLIVerbosityFlag:
+    """Test that CLI verbosity flag is properly configured."""
+
+    def test_implement_has_verbosity_argument(self):
+        """Test that implement subcommand has --verbosity argument."""
+        import argparse
+        from src.__main__ import main
+
+        # Parse help to check argument exists
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        impl_parser = subparsers.add_parser("implement")
+        impl_parser.add_argument("--verbosity", "-v", choices=["quiet", "normal", "verbose"])
+
+        args = impl_parser.parse_args(["--verbosity", "quiet"])
+        assert args.verbosity == "quiet"

--- a/tests/visualizers/test_reasoning_focused.py
+++ b/tests/visualizers/test_reasoning_focused.py
@@ -6,6 +6,8 @@ import json
 from unittest.mock import MagicMock
 
 from openhands.tools.delegate import DelegationVisualizer
+from openhands.tools.file_editor.definition import FileEditorAction
+from openhands.tools.terminal.definition import TerminalAction
 
 from src.visualizers import (
     QuietVisualizer,
@@ -14,6 +16,8 @@ from src.visualizers import (
     get_visualizer,
 )
 from src.visualizers.reasoning_focused import (
+    _clean_for_display,
+    _extract_action_detail,
     _extract_reasoning,
     _extract_summary_from_action,
     _truncate,
@@ -90,6 +94,94 @@ class TestTruncate:
         result = _truncate(text)
         assert len(result) == 100
 
+    def test_truncate_from_end(self):
+        """Test truncation from end (for paths)."""
+        text = "/very/long/path/to/some/file.py"
+        result = _truncate(text, 20, from_end=True)
+        assert result.startswith("...")
+        assert result.endswith("file.py")
+        assert len(result) == 20
+
+
+class TestCleanForDisplay:
+    """Tests for the _clean_for_display helper function."""
+
+    def test_strips_whitespace(self):
+        """Test that leading/trailing whitespace is stripped."""
+        assert _clean_for_display("  hello  ") == "hello"
+
+    def test_collapses_newlines(self):
+        """Test that newlines are replaced with spaces."""
+        assert _clean_for_display("hello\nworld") == "hello world"
+
+    def test_handles_multiple_newlines(self):
+        """Test handling of multiple newlines."""
+        assert _clean_for_display("a\n\nb\n\nc") == "a  b  c"
+
+
+class TestExtractActionDetail:
+    """Tests for the _extract_action_detail helper function."""
+
+    def test_terminal_action_shows_command(self):
+        """Test that terminal actions show the command."""
+        event = MagicMock()
+        event.action = TerminalAction(command="ls -la")
+        result = _extract_action_detail(event)
+        assert result == "$ ls -la"
+
+    def test_terminal_action_truncates_long_command(self):
+        """Test that long terminal commands are truncated."""
+        event = MagicMock()
+        event.action = TerminalAction(command="cat " + "x" * 100)
+        result = _extract_action_detail(event)
+        assert result is not None
+        assert result.startswith("$ cat ")
+        assert result.endswith("...")
+
+    def test_file_editor_view_shows_reading(self):
+        """Test that file_editor view shows 'Reading'."""
+        event = MagicMock()
+        event.action = FileEditorAction(command="view", path="/path/to/file.py")
+        result = _extract_action_detail(event)
+        assert result == "Reading /path/to/file.py"
+
+    def test_file_editor_edit_shows_editing(self):
+        """Test that file_editor str_replace shows 'Editing'."""
+        event = MagicMock()
+        event.action = FileEditorAction(
+            command="str_replace",
+            path="/path/to/file.py",
+            old_str="foo",
+            new_str="bar",
+        )
+        result = _extract_action_detail(event)
+        assert result == "Editing /path/to/file.py"
+
+    def test_file_editor_truncates_long_path_from_end(self):
+        """Test that long paths are truncated from the end."""
+        event = MagicMock()
+        long_path = "/very/long/nested/path/structure/to/important/file.py"
+        event.action = FileEditorAction(command="view", path=long_path)
+        result = _extract_action_detail(event)
+        assert result is not None
+        # Should preserve the filename at the end
+        assert result.endswith("file.py")
+        assert "..." in result
+
+    def test_returns_none_for_action_without_command_or_path(self):
+        """Test that None is returned for actions without extractable detail."""
+        event = MagicMock()
+        event.action = MagicMock(spec=[])  # No command or path attributes
+        result = _extract_action_detail(event)
+        assert result is None
+
+    def test_returns_none_for_none_action(self):
+        """Test that None is returned when action is None."""
+        event = MagicMock()
+        event.action = None
+        result = _extract_action_detail(event)
+        assert result is None
+
 
 class TestExtractSummaryFromAction:
     """Tests for the _extract_summary_from_action helper function."""
@@ -156,6 +248,47 @@ class TestReasoningFocusedVisualizer:
         """Test that show_observations defaults to False."""
         viz = ReasoningFocusedVisualizer(name="Test")
         assert viz._show_observations is False
+
+    def test_suppresses_system_prompt_event(self):
+        """Test that SystemPromptEvent is suppressed."""
+        from openhands.sdk.event import SystemPromptEvent
+
+        viz = ReasoningFocusedVisualizer(name="Test")
+        event = MagicMock(spec=SystemPromptEvent)
+        # Make isinstance check work
+        event.__class__ = SystemPromptEvent
+        result = viz._create_event_block(event)
+        assert result is None
+
+    def test_suppresses_condensation_request(self):
+        """Test that CondensationRequest is suppressed."""
+        from openhands.sdk.event.condenser import CondensationRequest
+
+        viz = ReasoningFocusedVisualizer(name="Test")
+        event = MagicMock(spec=CondensationRequest)
+        event.__class__ = CondensationRequest
+        result = viz._create_event_block(event)
+        assert result is None
+
+    def test_suppresses_condensation(self):
+        """Test that Condensation is suppressed."""
+        from openhands.sdk.event.condenser import Condensation
+
+        viz = ReasoningFocusedVisualizer(name="Test")
+        event = MagicMock(spec=Condensation)
+        event.__class__ = Condensation
+        result = viz._create_event_block(event)
+        assert result is None
+
+    def test_suppresses_conversation_state_update(self):
+        """Test that ConversationStateUpdateEvent is suppressed."""
+        from openhands.sdk.event import ConversationStateUpdateEvent
+
+        viz = ReasoningFocusedVisualizer(name="Test")
+        event = MagicMock(spec=ConversationStateUpdateEvent)
+        event.__class__ = ConversationStateUpdateEvent
+        result = viz._create_event_block(event)
+        assert result is None
 
 
 class TestQuietVisualizer:

--- a/tests/visualizers/test_reasoning_focused.py
+++ b/tests/visualizers/test_reasoning_focused.py
@@ -290,6 +290,32 @@ class TestReasoningFocusedVisualizer:
         result = viz._create_event_block(event)
         assert result is None
 
+    def test_handles_finish_action(self):
+        """Test that FinishAction creates a finish block."""
+        from openhands.sdk.event import ActionEvent
+        from openhands.sdk.tool.builtins.finish import FinishAction
+
+        viz = ReasoningFocusedVisualizer(name="Test")
+
+        # Create a mock ActionEvent with a FinishAction
+        finish_action = MagicMock(spec=FinishAction)
+        finish_action.message = "Task completed successfully"
+
+        event = MagicMock(spec=ActionEvent)
+        event.__class__ = ActionEvent
+        event.action = finish_action
+
+        result = viz._create_event_block(event)
+        # Should return a Group (not None)
+        assert result is not None
+
+    def test_create_finish_block_content(self):
+        """Test that _create_finish_block creates correct content."""
+        viz = ReasoningFocusedVisualizer(name="Test")
+        result = viz._create_finish_block("Task done!")
+        # Should return a Group
+        assert result is not None
+
 
 class TestQuietVisualizer:
     """Tests for QuietVisualizer."""

--- a/tests/visualizers/test_reasoning_focused.py
+++ b/tests/visualizers/test_reasoning_focused.py
@@ -304,6 +304,53 @@ class TestQuietVisualizer:
         viz = QuietVisualizer()
         assert viz._name is None
 
+    def test_timestamps_default_to_false(self):
+        """Test that show_timestamps defaults to False."""
+        viz = QuietVisualizer()
+        assert viz._show_timestamps is False
+
+    def test_timestamps_can_be_enabled(self):
+        """Test that show_timestamps can be enabled."""
+        viz = QuietVisualizer(show_timestamps=True)
+        assert viz._show_timestamps is True
+
+    def test_format_line_without_timestamps(self):
+        """Test _format_line without timestamps."""
+        viz = QuietVisualizer(show_timestamps=False)
+        result = viz._format_line("test message")
+        assert result == "test message"
+
+    def test_format_line_with_timestamps(self):
+        """Test _format_line with timestamps includes time prefix."""
+        viz = QuietVisualizer(show_timestamps=True)
+        result = viz._format_line("test message")
+        # Should start with a timestamp in [HH:MM:SS] format (with Rich escaping)
+        assert "[dim]\\[" in result  # Start of timestamp
+        assert "test message" in result
+
+    def test_format_line_with_agent_name(self):
+        """Test _format_line includes agent name prefix."""
+        viz = QuietVisualizer(name="SubAgent", show_timestamps=False)
+        result = viz._format_line("test message")
+        assert "[dim]\\[SubAgent][/dim]" in result
+        assert "test message" in result
+
+
+class TestGetVisualizerTimestamps:
+    """Tests for get_visualizer with timestamps parameter."""
+
+    def test_show_timestamps_passed_to_quiet_visualizer(self):
+        """Test that show_timestamps is passed to QuietVisualizer."""
+        viz = get_visualizer(Verbosity.QUIET, show_timestamps=True)
+        assert isinstance(viz, QuietVisualizer)
+        assert viz._show_timestamps is True
+
+    def test_show_timestamps_default_is_false(self):
+        """Test that show_timestamps defaults to False."""
+        viz = get_visualizer(Verbosity.QUIET)
+        assert isinstance(viz, QuietVisualizer)
+        assert viz._show_timestamps is False
+
 
 class TestCLIVerbosityFlag:
     """Test that CLI verbosity flag is properly configured."""

--- a/tests/visualizers/test_reasoning_focused.py
+++ b/tests/visualizers/test_reasoning_focused.py
@@ -393,3 +393,69 @@ class TestCLIVerbosityFlag:
 
         args = impl_parser.parse_args(["--verbosity", "quiet"])
         assert args.verbosity == "quiet"
+
+
+class TestAddVerbosityArguments:
+    """Tests for the _add_verbosity_arguments helper function."""
+
+    def test_adds_verbosity_argument(self):
+        """Test that helper adds --verbosity argument."""
+        import argparse
+
+        from src.__main__ import _add_verbosity_arguments
+
+        parser = argparse.ArgumentParser()
+        _add_verbosity_arguments(parser)
+
+        args = parser.parse_args(["--verbosity", "quiet"])
+        assert args.verbosity == "quiet"
+
+    def test_adds_timestamps_argument(self):
+        """Test that helper adds --timestamps argument."""
+        import argparse
+
+        from src.__main__ import _add_verbosity_arguments
+
+        parser = argparse.ArgumentParser()
+        _add_verbosity_arguments(parser)
+
+        args = parser.parse_args(["--timestamps"])
+        assert args.timestamps is True
+
+    def test_short_verbosity_flag(self):
+        """Test that -v short flag works."""
+        import argparse
+
+        from src.__main__ import _add_verbosity_arguments
+
+        parser = argparse.ArgumentParser()
+        _add_verbosity_arguments(parser)
+
+        args = parser.parse_args(["-v", "verbose"])
+        assert args.verbosity == "verbose"
+
+    def test_verbosity_choices(self):
+        """Test that only valid verbosity choices are accepted."""
+        import argparse
+
+        from src.__main__ import _add_verbosity_arguments
+
+        parser = argparse.ArgumentParser()
+        _add_verbosity_arguments(parser)
+
+        for level in ["quiet", "normal", "verbose"]:
+            args = parser.parse_args(["--verbosity", level])
+            assert args.verbosity == level
+
+    def test_default_values(self):
+        """Test that defaults are None for verbosity and False for timestamps."""
+        import argparse
+
+        from src.__main__ import _add_verbosity_arguments
+
+        parser = argparse.ArgumentParser()
+        _add_verbosity_arguments(parser)
+
+        args = parser.parse_args([])
+        assert args.verbosity is None
+        assert args.timestamps is False

--- a/uv.lock
+++ b/uv.lock
@@ -1695,6 +1695,12 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "basedpyright", marker = "extra == 'dev'", specifier = ">=1.36.0" },
@@ -1714,6 +1720,12 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.14.10" },
+]
 
 [[package]]
 name = "lxml"


### PR DESCRIPTION
## Summary

Implements a simpler visualization mode that emphasizes agent reasoning over technical details, addressing issue #38.

## Problem

The current visualization shows all event details by default, making it difficult to follow agent reasoning during normal operation. Output includes full thought content, action parameters, observation outputs, and more - valuable for debugging but overwhelming for watching the agent think.

## Solution

This PR adds three verbosity levels via a new `--verbosity` flag:

| Level | Output | Use Case |
|-------|--------|----------|
| `quiet` | Summaries only | CI/CD, log-focused monitoring |
| `normal` | Summary + reasoning (new default) | Normal usage - see what agent thinks |
| `verbose` | Full details | Debugging, previous behavior |

### Example Output

**Normal verbosity (new default):**
```
→ Check the README file contents
  I need to understand the project structure before implementing changes.
```

**Quiet verbosity:**
```
Orchestrator: Check the README file contents
```

**Verbose verbosity:**
Previous full-detail output with all action parameters, observation contents, etc.

## Changes

- **New `src/visualizers/` module:**
  - `ReasoningFocusedVisualizer`: Shows summary and reasoning, hides technical details
  - `QuietVisualizer`: Minimal output showing only action summaries  
  - `Verbosity` enum and `get_visualizer()` factory function

- **CLI changes:**
  - Added `--verbosity/-v` flag to `implement` subcommand
  - Supports `quiet`, `normal`, `verbose` options
  - Default changed from verbose to `normal`

- **Integration:**
  - Updated `run_orchestrator()` to use verbosity-aware visualizer
  - Updated `RalphLoopRunner` to support verbosity parameter

## Testing

- Added 22 new tests for visualizers module
- All 478 tests pass
- Type checking passes
- Linting passes

## Usage

```bash
# Normal (default) - reasoning-focused output
lxa implement

# Quiet - minimal output for CI/logs
lxa implement --verbosity quiet
lxa implement -v quiet

# Verbose - full details for debugging
lxa implement --verbosity verbose
lxa implement -v verbose
```

## References

- Closes #38
- Implementation based on analysis in issue #38 comparing OpenHands-CLI approach