### PR TITLE
Add review response principles for respond phase

### DIFF
--- a/doc/reference/pr-refinement.md
+++ b/doc/reference/pr-refinement.md
@@ -108,6 +108,33 @@ Self-review uses "roasted" code review principles inspired by Linus Torvalds:
 5. **Skip Style Nits**
    - Formatting, naming conventions = linter territory
 
+## Review Response Principles
+
+When responding to external review comments, the agent follows these principles:
+
+1. **Evaluate Before Acting**
+   - Assess whether reviewer feedback is valid before implementing
+   - Consider: Does this genuinely improve code quality, correctness, or maintainability?
+   - Not all feedback must be implemented, but valid concerns should be addressed
+
+2. **Fix Root Causes, Not Symptoms**
+   - Prefer fixing underlying issues over suppressing warnings
+   - If using `# type: ignore` or similar, explain why and verify no proper fix exists
+   - Ask: "Am I fixing this, or hiding it?"
+
+3. **Stay In Scope**
+   - Do not implement new features while responding to reviews
+   - Avoid scope creep beyond the PR's original purpose
+   - Suggest follow-up PRs for out-of-scope suggestions
+
+4. **Reasonable Cleanup Is OK**
+   - Opportunistic cleanup in the immediate area being touched is acceptable
+   - Keep cleanup proportional—don't refactor entire modules
+
+5. **Explain Your Decisions**
+   - When declining feedback, explain why respectfully
+   - When implementing, reference the commit that addresses it
+
 ## GitHub Integration
 
 The refinement loop uses GitHub's GraphQL API for review thread management:

--- a/src/ralph/refine.py
+++ b/src/ralph/refine.py
@@ -33,6 +33,7 @@ from src.ralph.github_review import (
 from src.ralph.refinement_config import (
     CODE_REVIEW_PRINCIPLES,
     COMMIT_GUIDELINES,
+    RESPOND_PRINCIPLES,
     SELF_REVIEW_WORKFLOW,
 )
 from src.ralph.runner import RefinementConfig
@@ -128,13 +129,17 @@ on PR #{pr_number} in repository {repo_slug}.
 EXISTING REVIEW THREADS TO ADDRESS:
 {review_threads}
 
+{respond_principles}
+
 WORKFLOW:
 1. Check out the PR branch: `gh pr checkout {pr_number} --repo {repo_slug}`
 2. Wait for CI to pass first
 3. For EACH unresolved review thread above:
-   a. Understand what the reviewer is asking
-   b. Make the fix or improvement
-   c. Commit with message: "Address review: [brief description]"
+   a. Read and understand what the reviewer is asking
+   b. Evaluate: Is this feedback valid? Would implementing it genuinely improve the code?
+   c. If valid: Make the fix, preferring root-cause solutions over workarounds
+   d. If not valid or out of scope: Prepare a respectful explanation
+   e. Commit with message: "Address review: [brief description]"
 4. Push your commits
 5. Wait for CI to pass
 6. After CI passes, reply to and resolve each thread:
@@ -145,8 +150,8 @@ WORKFLOW:
 IMPORTANT:
 - Address ALL unresolved threads, not just some
 - Push changes BEFORE replying to threads
-- Reply to each thread explaining what you did
-- Mark each thread as resolved after the fix is pushed
+- Reply to each thread explaining what you did (or why you declined)
+- Mark each thread as resolved after addressing it
 - Use the exact thread IDs provided above
 
 OUTPUT when done:
@@ -216,6 +221,7 @@ def create_respond_agent(
         repo_slug=repo_slug,
         review_threads=review_threads_text,
         thread_count=thread_count,
+        respond_principles=RESPOND_PRINCIPLES,
     )
 
     skills = [

--- a/src/ralph/refinement_config.py
+++ b/src/ralph/refinement_config.py
@@ -23,6 +23,39 @@ CODE REVIEW PRINCIPLES (Linus Torvalds style):
 5. SKIP STYLE NITS
    - Formatting, naming conventions = linter territory"""
 
+# Principles for responding to external review comments
+RESPOND_PRINCIPLES = """\
+RESPONDING TO REVIEW COMMENTS:
+
+1. EVALUATE BEFORE ACTING
+   - First, assess whether the reviewer's concern is valid
+   - Consider: Does this genuinely improve code quality, correctness, or maintainability?
+   - Not all feedback must be implemented - but valid concerns should be addressed
+
+2. FIX ROOT CAUSES, NOT SYMPTOMS
+   - Prefer fixing the underlying issue over suppressing warnings
+   - If using `# type: ignore`, `# noqa`, or similar suppressions:
+     * First verify there's no proper fix (correct import, upstream issue, etc.)
+     * Add a comment explaining WHY the suppression is necessary
+     * Consider filing an upstream issue if the problem is external
+   - Ask: "Am I fixing this, or hiding it?"
+
+3. STAY IN SCOPE
+   - Do not implement new features while responding to reviews
+   - Avoid scope creep beyond the PR's original purpose
+   - If a reviewer suggests something out of scope, acknowledge it and suggest
+     addressing it in a follow-up PR
+
+4. REASONABLE CLEANUP IS OK
+   - When touching code or tests in an area, opportunistic cleanup is acceptable
+   - Fix obvious issues in the immediate vicinity (same function, same test)
+   - Keep cleanup proportional - don't refactor entire modules
+
+5. EXPLAIN YOUR DECISIONS
+   - When declining feedback, explain why respectfully
+   - When implementing feedback, reference the commit that addresses it
+   - If partially addressing a concern, explain what you did and why"""
+
 # Shared refinement workflow for self-review
 SELF_REVIEW_WORKFLOW = """\
 WORKFLOW:


### PR DESCRIPTION
## Summary

Improves guidance for how the agent addresses external review comments during the "respond" phase of PR refinement. The current guidance was minimal ("make the fix or improvement") and didn't help the agent make thoughtful decisions about whether and how to address feedback.

## Problem

The existing respond phase guidance told the agent to:
- Understand what the reviewer is asking
- Make the fix or improvement
- Commit and resolve threads

This led to behaviors like:
- Blindly implementing all feedback without evaluating if it's valid
- Sidestepping issues with `# type: ignore` or similar suppressions instead of fixing root causes
- Scope creep when reviewers suggest new features
- Not explaining decisions when declining feedback

## Solution

Add `RESPOND_PRINCIPLES` to `refinement_config.py` with five key principles:

1. **Evaluate Before Acting** - Assess whether feedback is valid and genuinely improves code quality before implementing
2. **Fix Root Causes, Not Symptoms** - Prefer actual fixes over suppressions; if suppressing, explain why
3. **Stay In Scope** - Don't implement new features during review response; suggest follow-up PRs
4. **Reasonable Cleanup Is OK** - Allow opportunistic cleanup in the immediate area being touched
5. **Explain Your Decisions** - When declining or implementing, communicate clearly

## Changes

- `src/ralph/refinement_config.py`: Added `RESPOND_PRINCIPLES` constant
- `src/ralph/refine.py`: Import and inject principles into respond prompt, updated workflow steps
- `doc/reference/pr-refinement.md`: Documented the new principles

## Testing

- All lint checks pass (`ruff check`)
- All type checks pass (`pyright`)
