### PR TITLE
Fix: new boards no longer inherit repos from default board

### DIFF
--- a/src/board/cli/init.py
+++ b/src/board/cli/init.py
@@ -11,6 +11,7 @@ from src.board.cli._helpers import (
     print_warning,
 )
 from src.board.config import (
+    BoardConfig,
     load_board_config,
     load_boards_config,
     save_board_config,
@@ -44,8 +45,8 @@ def cmd_init(
     """
     print_command_header("lxa board init")
 
-    # For new projects, we don't load existing config
-    config = load_board_config(board_name) if not create_name else load_board_config()
+    # For new projects, start with empty config (don't inherit repos from default)
+    config = load_board_config(board_name) if not create_name else BoardConfig()
     cache = BoardCache()
 
     # Determine username

--- a/tests/board/test_cli_smoke.py
+++ b/tests/board/test_cli_smoke.py
@@ -122,6 +122,79 @@ class TestBoardCommandsSmoke:
             or "No project specified" in captured.out
         )
 
+    def test_cmd_init_create_does_not_inherit_repos_from_default(
+        self,
+        mock_config_dir,  # noqa: ARG002
+        monkeypatch,
+    ):
+        """Test that creating a new board doesn't inherit repos from default board.
+
+        Regression test for bug where new boards would inherit repos from the
+        default board configuration.
+        """
+        from unittest.mock import MagicMock
+
+        from src.board.config import BoardConfig, load_board_config, save_board_config
+
+        # First create a default board with some repos
+        default_config = BoardConfig(
+            name="main",
+            project_id="PVT_default",
+            project_number=1,
+            username="testuser",
+            repos=["owner/repo1", "owner/repo2"],
+        )
+        save_board_config(default_config, "main")
+
+        # Verify default board has repos
+        loaded_default = load_board_config("main")
+        assert loaded_default.repos == ["owner/repo1", "owner/repo2"]
+
+        # Mock GitHubClient and API calls
+        mock_client = MagicMock()
+        mock_client.get_user_id.return_value = "U_test"
+        mock_project = MagicMock()
+        mock_project.number = 2
+        mock_project.id = "PVT_new"
+        mock_project.url = "https://github.com/users/testuser/projects/2"
+        mock_project.title = "New Project"
+        mock_project.status_field_id = "PVTF_new"
+        mock_project.column_option_ids = {"Backlog": "opt1"}
+        mock_client.create_project.return_value = mock_project
+        mock_client.get_user_project.return_value = mock_project
+        mock_client.update_status_field_options.return_value = {"Backlog": "opt1"}
+
+        monkeypatch.setattr(
+            "src.board.cli.init.get_github_username",
+            lambda: "testuser",
+        )
+
+        # Make GitHubClient a context manager that returns our mock
+        mock_context = MagicMock()
+        mock_context.__enter__ = MagicMock(return_value=mock_client)
+        mock_context.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setattr(
+            "src.board.cli.init.GitHubClient",
+            lambda: mock_context,
+        )
+
+        # Create a new board
+        from src.board.cli import cmd_init
+
+        result = cmd_init(
+            create_name="New Project",
+            project_id=None,
+            project_number=None,
+            board_name="new-project",
+            dry_run=False,
+        )
+
+        assert result == 0
+
+        # The new board should NOT have repos from the default board
+        new_board = load_board_config("new-project")
+        assert new_board.repos == [], f"New board inherited repos from default: {new_board.repos}"
+
     def test_cmd_config_repos_add(self, mock_config_dir, capsys):  # noqa: ARG002
         """Test adding a repo to watch list."""
         from src.board.cli import cmd_config


### PR DESCRIPTION
## Summary
When creating a new board with `lxa board init --create`, the board would incorrectly inherit the repos list from the default board.

## Root Cause
The init command called `load_board_config()` without arguments for new boards, which loads the default board's config including its repos. The config was then saved to the new board, carrying over repos that shouldn't be there.

## Fix
Use `BoardConfig()` to create an empty config for new boards instead of inheriting from the default.

## Changes
- **src/board/cli/init.py**: Use `BoardConfig()` for new board creation instead of `load_board_config()`
- **tests/board/test_cli_smoke.py**: Added regression test to prevent this bug from recurring

## Testing
- All existing tests pass
- Added specific regression test for this scenario
- Verified with actual config that the fix works