### PR TITLE
feat(board): Add project-scoped boards with overview_item and mission

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1170,6 +1170,16 @@ Configuration:
         help="Name for this board in config (default: slugified project name)",
     )
     board_init_parser.add_argument(
+        "--scope",
+        choices=["user", "project"],
+        help="Board scope: 'user' (default) or 'project' for project-scoped boards",
+    )
+    board_init_parser.add_argument(
+        "--overview",
+        metavar="URL",
+        help="URL of overview item (required for project-scoped boards)",
+    )
+    board_init_parser.add_argument(
         "--dry-run",
         "-n",
         action="store_true",
@@ -1601,6 +1611,8 @@ Configuration:
                 project_id=args.project_id,
                 project_number=args.project_number,
                 board_name=args.board,
+                scope=args.scope,
+                overview=args.overview,
                 dry_run=args.dry_run,
             )
 

--- a/src/board/cli/init.py
+++ b/src/board/cli/init.py
@@ -1,5 +1,7 @@
 """Board init command - create or configure GitHub Project boards."""
 
+from dataclasses import dataclass
+
 from rich.console import Console
 
 from src.board.cache import BoardCache
@@ -12,6 +14,7 @@ from src.board.cli._helpers import (
 )
 from src.board.config import (
     BoardConfig,
+    BoardScope,
     load_board_config,
     load_boards_config,
     save_board_config,
@@ -23,12 +26,22 @@ from src.board.models import get_default_columns
 console = Console()
 
 
+@dataclass
+class InitOptions:
+    """Options for board initialization commands."""
+
+    board_name: str | None = None
+    dry_run: bool = False
+
+
 def cmd_init(
     *,
     create_name: str | None = None,
     project_id: str | None = None,
     project_number: int | None = None,
     board_name: str | None = None,
+    scope: str | None = None,
+    overview: str | None = None,
     dry_run: bool = False,
 ) -> int:
     """Initialize or configure a GitHub Project board.
@@ -38,6 +51,8 @@ def cmd_init(
         project_id: GraphQL ID of existing project
         project_number: Number of existing user project
         board_name: Name for this board in config (default: slugified project name)
+        scope: Board scope ("user" or "project")
+        overview: URL of overview item (for project-scoped boards)
         dry_run: Show what would be done without making changes
 
     Returns:
@@ -45,9 +60,29 @@ def cmd_init(
     """
     print_command_header("lxa board init")
 
+    # Validate scope and overview combination
+    if scope == BoardScope.PROJECT and not overview:
+        print_error("Project-scoped boards require --overview")
+        print_info("Specify the overview item URL: --overview https://github.com/...", dim=True)
+        return 1
+
+    if overview and scope != BoardScope.PROJECT:
+        print_warning("--overview is only used with --scope project")
+        print_info("Setting scope to 'project'", dim=True)
+        scope = BoardScope.PROJECT
+
     # For new projects, start with empty config (don't inherit repos from default)
     config = load_board_config(board_name) if not create_name else BoardConfig()
     cache = BoardCache()
+
+    # Set scope and overview on config early (they'll be persisted when config is saved)
+    if scope:
+        config.scope = scope
+    if overview:
+        config.overview_item = overview
+
+    # Bundle options for cleaner parameter passing
+    options = InitOptions(board_name=board_name, dry_run=dry_run)
 
     # Determine username
     username = config.username or get_github_username()
@@ -61,45 +96,47 @@ def cmd_init(
     with GitHubClient() as client:
         # Case 1: Create new project
         if create_name:
-            return _create_new_project(
-                client, cache, config, create_name, board_name, username, dry_run
-            )
+            return _create_new_project(client, cache, config, create_name, username, options)
 
         # Case 2: Configure existing project by ID
         if project_id:
-            return _configure_by_id(
-                client, cache, config, project_id, board_name, username, dry_run
-            )
+            return _configure_by_id(client, cache, config, project_id, username, options)
 
         # Case 3: Configure existing project by number
         if project_number:
-            return _configure_by_number(
-                client, cache, config, project_number, board_name, username, dry_run
-            )
+            return _configure_by_number(client, cache, config, project_number, username, options)
 
         # Case 4: Use configured project
         if config.project_id:
-            return _configure_existing(client, cache, config, board_name, username, dry_run)
+            return _configure_existing(client, cache, config, username, options)
 
         if config.project_number:
             return _configure_by_number(
-                client, cache, config, config.project_number, board_name, username, dry_run
+                client, cache, config, config.project_number, username, options
             )
 
         # No project specified
         print_error("No project specified")
         console.print("\nUsage:")
         console.print("  lxa board init --create 'Project Name'  # Create new")
+        console.print(
+            "  lxa board init --create 'Name' --scope project --overview <url>  # Project-scoped"
+        )
         console.print("  lxa board init --project-number 5       # Configure existing")
         console.print("  lxa board init --project-id PVT_xxx     # Configure by ID")
         return 1
 
 
 def _create_new_project(
-    client, cache, config, create_name: str, board_name: str | None, username: str, dry_run: bool
+    client,
+    cache,
+    config: BoardConfig,
+    create_name: str,
+    username: str,
+    options: InitOptions,
 ) -> int:
     """Create a new GitHub Project."""
-    config_name = board_name or slugify(create_name)
+    config_name = options.board_name or slugify(create_name)
 
     # Check if board already exists
     boards = load_boards_config()
@@ -108,8 +145,11 @@ def _create_new_project(
 
     console.print(f"\nCreating project: [cyan]{create_name}[/]")
     print_info(f"Config name: {config_name}", dim=True)
+    if config.is_project_scoped:
+        print_info("Scope: project", dim=True)
+        print_info(f"Overview: {config.overview_item}", dim=True)
 
-    if dry_run:
+    if options.dry_run:
         console.print("[yellow]Dry run - would create project[/]")
         return 0
 
@@ -136,7 +176,7 @@ def _create_new_project(
         project.column_option_ids = column_options
         print_success(f"Created Status field with {len(column_options)} columns")
 
-    # Save to config
+    # Save to config (scope and overview_item already set on config)
     config.name = config_name
     config.project_id = project.id
     config.project_number = project.number
@@ -145,12 +185,17 @@ def _create_new_project(
     cache.cache_project_info(project)
     print_success(f"Saved configuration as '{config_name}'")
 
-    _print_next_steps()
+    _print_next_steps(config.is_project_scoped)
     return 0
 
 
 def _configure_by_id(
-    client, cache, config, project_id: str, board_name: str | None, username: str, dry_run: bool
+    client,
+    cache,
+    config: BoardConfig,
+    project_id: str,
+    username: str,
+    options: InitOptions,
 ) -> int:
     """Configure an existing project by GraphQL ID."""
     console.print(f"\nConfiguring project: [cyan]{project_id}[/]")
@@ -159,11 +204,16 @@ def _configure_by_id(
         print_error(f"Project not found: {project_id}")
         return 1
 
-    return _finish_configure(client, cache, config, project, board_name, username, dry_run)
+    return _finish_configure(client, cache, config, project, username, options)
 
 
 def _configure_by_number(
-    client, cache, config, project_number: int, board_name: str | None, username: str, dry_run: bool
+    client,
+    cache,
+    config: BoardConfig,
+    project_number: int,
+    username: str,
+    options: InitOptions,
 ) -> int:
     """Configure an existing project by number."""
     console.print(f"\nConfiguring project #{project_number}")
@@ -172,11 +222,15 @@ def _configure_by_number(
         print_error(f"Project #{project_number} not found for {username}")
         return 1
 
-    return _finish_configure(client, cache, config, project, board_name, username, dry_run)
+    return _finish_configure(client, cache, config, project, username, options)
 
 
 def _configure_existing(
-    client, cache, config, board_name: str | None, username: str, dry_run: bool
+    client,
+    cache,
+    config: BoardConfig,
+    username: str,
+    options: InitOptions,
 ) -> int:
     """Configure using existing project from config."""
     console.print(f"\nUsing configured project: [cyan]{config.project_id}[/]")
@@ -185,15 +239,24 @@ def _configure_existing(
         print_error("Configured project not found")
         return 1
 
-    return _finish_configure(client, cache, config, project, board_name, username, dry_run)
+    return _finish_configure(client, cache, config, project, username, options)
 
 
 def _finish_configure(
-    client, cache, config, project, board_name: str | None, username: str, dry_run: bool
+    client,
+    cache,
+    config: BoardConfig,
+    project,
+    username: str,
+    options: InitOptions,
 ) -> int:
     """Complete project configuration (check/update Status field)."""
     print_success(f"Found project: {project.title}")
     console.print(f"  URL: {project.url}")
+
+    if config.is_project_scoped:
+        print_info("Scope: project", dim=True)
+        print_info(f"Overview: {config.overview_item}", dim=True)
 
     # Check/configure Status field
     if project.status_field_id:
@@ -204,7 +267,7 @@ def _finish_configure(
 
         if missing:
             console.print(f"[yellow]Missing columns:[/] {', '.join(missing)}")
-            if dry_run:
+            if options.dry_run:
                 console.print("[yellow]Dry run - would add missing columns[/]")
             else:
                 console.print("Updating Status field...")
@@ -215,7 +278,7 @@ def _finish_configure(
                 print_success(f"Updated Status field ({len(column_options)} columns)")
     else:
         console.print("[yellow]Creating Status field...[/]")
-        if dry_run:
+        if options.dry_run:
             console.print("[yellow]Dry run - would create Status field[/]")
         else:
             field_id, column_options = client.create_status_field(project.id)
@@ -223,9 +286,9 @@ def _finish_configure(
             project.column_option_ids = column_options
             print_success(f"Created Status field with {len(column_options)} columns")
 
-    if not dry_run:
-        # Save to config
-        config_name = board_name or config.name or slugify(project.title)
+    if not options.dry_run:
+        # Save to config (scope and overview_item already set on config)
+        config_name = options.board_name or config.name or slugify(project.title)
         config.name = config_name
         config.project_id = project.id
         config.project_number = project.number
@@ -237,12 +300,18 @@ def _finish_configure(
     return 0
 
 
-def _print_next_steps() -> None:
+def _print_next_steps(is_project_scoped: bool = False) -> None:
     """Print next steps after project creation."""
     console.print("\n[bold]Next steps:[/]")
     console.print("  1. Add repos to watch:")
     console.print("     [dim]lxa board config repos add owner/repo[/]")
-    console.print("  2. Scan for issues and PRs:")
-    console.print("     [dim]lxa board scan[/]")
-    console.print("  3. Check board status:")
-    console.print("     [dim]lxa board status[/]")
+    if is_project_scoped:
+        console.print("  2. Add items manually:")
+        console.print("     [dim]lxa board add-item <url>[/]")
+        console.print("  3. Check board status:")
+        console.print("     [dim]lxa board status[/]")
+    else:
+        console.print("  2. Scan for issues and PRs:")
+        console.print("     [dim]lxa board scan[/]")
+        console.print("  3. Check board status:")
+        console.print("     [dim]lxa board status[/]")

--- a/src/board/cli/scan.py
+++ b/src/board/cli/scan.py
@@ -12,6 +12,7 @@ from src.board.cli._helpers import (
     print_command_header,
     print_error,
     print_info,
+    print_success,
     print_sync_summary,
     print_warning,
 )
@@ -95,6 +96,12 @@ def cmd_scan(
     cache = BoardCache()
 
     print_info(f"Board: {config.name}", dim=True)
+
+    # Handle project-scoped boards differently
+    if config.is_project_scoped:
+        return _scan_project_scoped(config, cache)
+
+    # Continue with user-scoped board scan
 
     # Validate mutually exclusive options
     if sum(bool(x) for x in [repos, scan_user, scan_org]) > 1:
@@ -194,3 +201,26 @@ def cmd_scan(
         cache.set_last_sync()
 
     return 0 if result.success else 1
+
+
+def _scan_project_scoped(config, cache) -> int:  # noqa: ARG001
+    """Handle scan for project-scoped boards.
+
+    Project-scoped boards do NOT auto-add items based on user involvement.
+    This function just verifies the overview item is on the board.
+    """
+    console.print(f'\nBoard [cyan]"{config.name}"[/] is project-scoped.')
+    console.print("Scan does not auto-add items to project-scoped boards.\n")
+
+    # Display overview item status
+    if config.overview_item:
+        # For now, we just display the configured overview item
+        # In the future, we could verify it's on the board
+        print_success(f"Overview item: {config.overview_item}")
+    else:
+        print_warning("No overview item configured")
+
+    console.print("\nTo add items manually: [dim]lxa board add-item <url>[/]")
+    console.print("[dim]Smart scanning will be available in a future release.[/]")
+
+    return 0

--- a/src/board/cli/status.py
+++ b/src/board/cli/status.py
@@ -48,6 +48,10 @@ def cmd_status(
 
     print_command_header("lxa board status")
 
+    # Display project metadata for project-scoped boards
+    if config.is_project_scoped:
+        _print_project_metadata(config)
+
     _print_last_sync_info(cache)
     _print_status_table(counts, attention)
 
@@ -61,9 +65,15 @@ def _build_json_output(config, counts: dict, cache: BoardCache, verbose: bool) -
     """Build JSON output for status command."""
     data = {
         "project_id": config.project_id,
+        "scope": config.scope,
         "columns": counts,
         "total": sum(counts.values()),
     }
+    # Include project-scoped metadata
+    if config.is_project_scoped:
+        data["overview_item"] = config.overview_item
+        if config.mission:
+            data["mission"] = config.mission
     if verbose:
         data["items"] = {}
         for col_name in get_default_columns():
@@ -72,6 +82,24 @@ def _build_json_output(config, counts: dict, cache: BoardCache, verbose: bool) -
                 {"repo": i.repo, "number": i.number, "title": i.title} for i in items
             ]
     return data
+
+
+def _print_project_metadata(config) -> None:
+    """Print project metadata for project-scoped boards."""
+    console.print(f"[bold]Board:[/] {config.name}")
+    console.print("[bold]Scope:[/] project")
+
+    if config.overview_item:
+        console.print(f"[bold]Overview:[/] {config.overview_item}")
+
+    if config.mission:
+        console.print()
+        console.print("[bold]Mission:[/]")
+        # Indent mission text
+        for line in config.mission.strip().split("\n"):
+            console.print(f"  {line}")
+
+    console.print()
 
 
 def _print_last_sync_info(cache: BoardCache) -> None:

--- a/src/board/config.py
+++ b/src/board/config.py
@@ -103,6 +103,13 @@ def slugify(name: str) -> str:
     return slug or "board"
 
 
+class BoardScope:
+    """Board scope types."""
+
+    USER = "user"
+    PROJECT = "project"
+
+
 @dataclass
 class BoardConfig:
     """Configuration for a single board."""
@@ -134,9 +141,24 @@ class BoardConfig:
     # Sync metadata: when this board config was last updated
     updated_at: datetime | None = None
 
+    # Board scope: "user" (default, current behavior) or "project"
+    scope: str = BoardScope.USER
+
+    # The anchor item that defines the project (for project-scoped boards)
+    # URL to a GitHub issue/PR that serves as the project overview
+    overview_item: str | None = None
+
+    # Human-readable project mission (for agent context and smart scanning)
+    mission: str | None = None
+
     def touch(self) -> None:
         """Update the updated_at timestamp to now."""
         self.updated_at = datetime.now(tz=UTC)
+
+    @property
+    def is_project_scoped(self) -> bool:
+        """Check if this is a project-scoped board."""
+        return self.scope == BoardScope.PROJECT
 
     def get_column_name(self, column_key: str) -> str:
         """Get the column name, using custom mapping if set."""
@@ -150,6 +172,7 @@ class BoardConfig:
             COLUMN_FINAL_REVIEW,
             COLUMN_HUMAN_REVIEW,
             COLUMN_ICEBOX,
+            COLUMN_TRIAGE,
         )
 
         # Use custom mapping if provided
@@ -158,6 +181,7 @@ class BoardConfig:
 
         # Default mapping
         defaults = {
+            "triage": COLUMN_TRIAGE,
             "icebox": COLUMN_ICEBOX,
             "backlog": COLUMN_BACKLOG,
             "agent_coding": COLUMN_AGENT_CODING,
@@ -402,6 +426,9 @@ def load_boards_config() -> BoardsConfig:
                 agent_username_pattern=value.get("agent_username_pattern", "openhands"),
                 column_names=value.get("columns", {}),
                 updated_at=_parse_datetime(value.get("_updated_at")),
+                scope=value.get("scope", BoardScope.USER),
+                overview_item=value.get("overview_item"),
+                mission=value.get("mission"),
             )
 
     return BoardsConfig(
@@ -480,6 +507,12 @@ def save_boards_config(config: BoardsConfig) -> None:
             entry["columns"] = board.column_names
         if board.updated_at:
             entry["_updated_at"] = _format_datetime(board.updated_at)
+        if board.scope != BoardScope.USER:
+            entry["scope"] = board.scope
+        if board.overview_item:
+            entry["overview_item"] = board.overview_item
+        if board.mission:
+            entry["mission"] = board.mission
 
         board_data[name] = entry
 

--- a/src/board/models.py
+++ b/src/board/models.py
@@ -18,6 +18,7 @@ class ItemType(Enum):
 
 
 # Column name constants - used as canonical column names
+COLUMN_TRIAGE = "Triage"
 COLUMN_ICEBOX = "Icebox"
 COLUMN_BACKLOG = "Backlog"
 COLUMN_AGENT_CODING = "Agent Coding"
@@ -30,6 +31,7 @@ COLUMN_CLOSED = "Closed"
 
 # Columns that need human attention
 ATTENTION_COLUMNS = {
+    COLUMN_TRIAGE,
     COLUMN_HUMAN_REVIEW,
     COLUMN_FINAL_REVIEW,
     COLUMN_APPROVED,

--- a/src/board/yaml_config.py
+++ b/src/board/yaml_config.py
@@ -32,6 +32,10 @@ agent_pattern: "openhands"
 
 # Column definitions - order determines display order on board
 columns:
+  - name: Triage
+    color: GRAY
+    description: "Items pending review for relevance to project"
+
   - name: Icebox
     color: GRAY
     description: "Auto-closed due to inactivity; awaiting triage"

--- a/tests/board/test_config.py
+++ b/tests/board/test_config.py
@@ -5,6 +5,7 @@ import pytest
 from src.board.config import (
     BoardConfig,
     BoardsConfig,
+    BoardScope,
     add_watched_repo,
     list_boards,
     load_board_config,
@@ -57,6 +58,9 @@ class TestBoardConfig:
         assert config.repos == []
         assert config.scan_lookback_days == 90
         assert config.agent_username_pattern == "openhands"
+        assert config.scope == BoardScope.USER
+        assert config.overview_item is None
+        assert config.mission is None
 
     def test_watched_repos_alias(self):
         """Test that watched_repos is an alias for repos."""
@@ -70,11 +74,32 @@ class TestBoardConfig:
         config = BoardConfig()
         assert config.get_column_name("backlog") == "Backlog"
         assert config.get_column_name("done") == "Done"
+        assert config.get_column_name("triage") == "Triage"
 
     def test_get_column_name_custom(self):
         config = BoardConfig(column_names={"backlog": "Custom Backlog"})
         assert config.get_column_name("backlog") == "Custom Backlog"
         assert config.get_column_name("done") == "Done"  # Still uses default
+
+    def test_is_project_scoped(self):
+        """Test is_project_scoped property."""
+        user_board = BoardConfig(scope=BoardScope.USER)
+        assert user_board.is_project_scoped is False
+
+        project_board = BoardConfig(scope=BoardScope.PROJECT)
+        assert project_board.is_project_scoped is True
+
+    def test_project_scoped_board_fields(self):
+        """Test project-scoped board specific fields."""
+        config = BoardConfig(
+            name="project-board",
+            scope=BoardScope.PROJECT,
+            overview_item="https://github.com/owner/repo/issues/123",
+            mission="Build the best feature ever",
+        )
+        assert config.is_project_scoped is True
+        assert config.overview_item == "https://github.com/owner/repo/issues/123"
+        assert config.mission == "Build the best feature ever"
 
 
 class TestBoardsConfig:
@@ -414,3 +439,84 @@ class TestNonDefaultSettings:
         content = config_file.read_text()
         assert "scan_lookback_days" not in content
         assert "agent_username_pattern" not in content
+
+
+class TestProjectScopedBoards:
+    """Tests for project-scoped board configuration."""
+
+    def test_save_and_load_project_scoped_board(self, temp_config_dir):  # noqa: ARG002
+        """Save and load a project-scoped board configuration."""
+        board = BoardConfig(
+            name="plugin-directory",
+            project_id="PVT_123",
+            project_number=5,
+            username="testuser",
+            repos=["OpenHands/OpenHands"],
+            scope=BoardScope.PROJECT,
+            overview_item="https://github.com/OpenHands/OpenHands/issues/12085",
+            mission="Build the plugin directory feature",
+        )
+
+        save_board_config(board, "plugin-directory")
+
+        # Load it back
+        loaded = load_board_config("plugin-directory")
+        assert loaded.name == "plugin-directory"
+        assert loaded.scope == BoardScope.PROJECT
+        assert loaded.is_project_scoped is True
+        assert loaded.overview_item == "https://github.com/OpenHands/OpenHands/issues/12085"
+        assert loaded.mission == "Build the plugin directory feature"
+
+    def test_user_scope_not_saved(self, temp_config_dir):  # noqa: ARG002
+        """User scope (default) is not written to file."""
+        tmp_path, config_file = temp_config_dir
+
+        board = BoardConfig(
+            name="test",
+            project_id="PVT_123",
+            scope=BoardScope.USER,  # default
+        )
+        save_board_config(board, "test")
+
+        content = config_file.read_text()
+        assert "scope" not in content
+
+    def test_project_scope_is_saved(self, temp_config_dir):  # noqa: ARG002
+        """Project scope is written to file."""
+        tmp_path, config_file = temp_config_dir
+
+        board = BoardConfig(
+            name="test",
+            project_id="PVT_123",
+            scope=BoardScope.PROJECT,
+            overview_item="https://github.com/owner/repo/issues/1",
+        )
+        save_board_config(board, "test")
+
+        content = config_file.read_text()
+        assert "scope" in content
+        assert "project" in content
+        assert "overview_item" in content
+
+    def test_multiline_mission_saved(self, temp_config_dir):  # noqa: ARG002
+        """Multiline mission text is properly saved and loaded."""
+        mission = """This project delivers the ability for users to discover plugins.
+
+In scope:
+- Plugin manifest schema
+- Marketplace UI
+
+Out of scope:
+- General CI/CD infrastructure"""
+
+        board = BoardConfig(
+            name="test",
+            project_id="PVT_123",
+            scope=BoardScope.PROJECT,
+            overview_item="https://github.com/owner/repo/issues/1",
+            mission=mission,
+        )
+        save_board_config(board, "test")
+
+        loaded = load_board_config("test")
+        assert loaded.mission == mission

--- a/tests/board/test_models.py
+++ b/tests/board/test_models.py
@@ -3,6 +3,7 @@
 from src.board.models import (
     COLUMN_CLOSED,
     COLUMN_ICEBOX,
+    COLUMN_TRIAGE,
     Item,
     ItemType,
     get_column_color,
@@ -17,8 +18,9 @@ class TestColumnHelpers:
     def test_get_default_columns_returns_all_columns_in_order(self):
         """Verify get_default_columns returns correct columns."""
         columns = get_default_columns()
-        assert len(columns) == 9
-        assert columns[0] == COLUMN_ICEBOX
+        assert len(columns) == 10  # Including Triage column
+        assert columns[0] == COLUMN_TRIAGE
+        assert columns[1] == COLUMN_ICEBOX
         assert columns[-1] == COLUMN_CLOSED
 
     def test_get_column_color_returns_valid_colors(self):

--- a/tests/board/test_yaml_config.py
+++ b/tests/board/test_yaml_config.py
@@ -297,11 +297,12 @@ class TestTemplates:
         board = load_board_from_string(template)
 
         assert board.name == "Agent Development Board"
-        assert len(board.columns) == 9  # All workflow columns
+        assert len(board.columns) == 10  # All workflow columns including Triage
         assert len(board.rules) >= 9  # All default rules
 
         # Verify column names
         column_names = board.column_names
+        assert "Triage" in column_names
         assert "Icebox" in column_names
         assert "Backlog" in column_names
         assert "Agent Coding" in column_names


### PR DESCRIPTION
## Summary

Add support for project-scoped boards that track a fixed set of items related to a specific project/initiative, as opposed to user-activity boards that track all items where a user is involved.

This is the foundation for project-scoped boards. Smart scanning (automatic discovery of related items) will be added in a follow-up issue (#62).

## Changes

### BoardConfig (`src/board/config.py`)
- Add `BoardScope` class with `USER` and `PROJECT` constants
- Add `scope` field: `"user"` (default) or `"project"`
- Add `overview_item` field: URL of anchor item that defines the project
- Add `mission` field: Human-readable project mission for agent context
- Add `is_project_scoped` property for easy checking
- Update save/load to persist new fields

### Init Command (`src/board/cli/init.py`)
- Add `--scope` option: `user` (default) or `project`
- Add `--overview` option: URL of overview item for project-scoped boards
- Validate that project-scoped boards require `--overview`
- Show different next steps for project-scoped vs user-scoped boards

### Scan Command (`src/board/cli/scan.py`)
- For project-scoped boards, do NOT auto-add items based on user involvement
- Display informative message explaining manual addition for project boards
- Display overview item status

### Status Command (`src/board/cli/status.py`)
- Display project metadata (board name, scope, overview, mission) for project-scoped boards
- Include metadata in JSON output (`scope`, `overview_item`, `mission`)

### Default Template (`src/board/yaml_config.py`)
- Add `Triage` column for items pending review for relevance to project
- Add `COLUMN_TRIAGE` constant to models

### Tests
- Add tests for new BoardConfig fields and `is_project_scoped` property
- Add tests for saving/loading project-scoped board configurations
- Update existing tests for 10 columns (with Triage)

## Usage

### Create a project-scoped board
```bash
lxa board init --create "Plugin Directory" --scope project --overview https://github.com/OpenHands/OpenHands/issues/12085
```

### Scan behavior for project-scoped boards
```
$ lxa board scan

Board "Plugin Directory" is project-scoped.
Scan does not auto-add items to project-scoped boards.

✓ Overview item: https://github.com/OpenHands/OpenHands/issues/12085

To add items manually: lxa board add-item <url>
Smart scanning will be available in a future release.
```

### Status output for project-scoped boards
```
$ lxa board status

Board: Plugin Directory & Launch
Scope: project
Overview: https://github.com/OpenHands/OpenHands/issues/12085

Mission:
  This project delivers the ability for users to discover plugins...

Columns:
  Triage: 0
  Backlog: 3
  ...
```

## Example Configuration

```yaml
board:
  name: "Plugin Directory & Launch"
  scope: project
  overview_item: https://github.com/OpenHands/OpenHands/issues/12085
  mission: |
    This project delivers the ability for users to discover plugins in a 
    marketplace and launch conversations with pre-configured plugins.
    
    In scope:
    - /launch route implementation
    - Plugin manifest schema and validation
    - Marketplace/directory UI and backend

repos:
  - OpenHands/OpenHands
  - OpenHands/software-agent-sdk
```

## Testing

All 192 board tests pass:
```
tests/board/ - 192 passed
```

Closes #61