### PR TITLE
chore: pin openhands-sdk and openhands-tools to 1.16.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ dynamic = ["version"]
 description = "LXA (Long Execution Agent) - Agent-assisted software development"
 requires-python = ">=3.12"
 dependencies = [
-    "openhands-sdk>=1.12.0",
-    "openhands-tools>=1.12.0",
+    "openhands-sdk==1.16.1",
+    "openhands-tools==1.16.1",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",
     "mdformat>=0.7",


### PR DESCRIPTION
## Summary

Update dependencies to use the latest version of OpenHands software-agent-sdk.

## Changes

- Pin `openhands-sdk` from `>=1.12.0` to `==1.16.1`
- Pin `openhands-tools` from `>=1.12.0` to `==1.16.1`

This ensures the project uses a known, tested version of the SDK and prevents potential breaking changes from future releases.

---

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a1f35e08-d6a0-4a75-9ab4-ac887a2bba4b)