### PR TITLE
feat: Add background job management with detached execution

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -539,6 +539,18 @@ Configuration:
         default=5,
         help="Maximum refinement iterations (default: 5)",
     )
+    implement_parser.add_argument(
+        "--background",
+        "-b",
+        action="store_true",
+        help="Run in background (detached from terminal)",
+    )
+    implement_parser.add_argument(
+        "--job-name",
+        type=str,
+        default=None,
+        help="Custom name for background job (default: 'implement')",
+    )
 
     # Reconcile subcommand
     reconcile_parser = subparsers.add_parser(
@@ -608,6 +620,122 @@ Configuration:
         choices=["auto", "self-review", "respond"],
         default="auto",
         help="Phase to run: auto (detect), self-review, or respond (default: auto)",
+    )
+    refine_parser.add_argument(
+        "--background",
+        "-b",
+        action="store_true",
+        help="Run in background (detached from terminal)",
+    )
+    refine_parser.add_argument(
+        "--job-name",
+        type=str,
+        default=None,
+        help="Custom name for background job (default: 'refine')",
+    )
+
+    # Job subcommand (with nested subcommands)
+    job_parser = subparsers.add_parser(
+        "job",
+        help="Manage background jobs",
+    )
+    job_subparsers = job_parser.add_subparsers(dest="job_command", required=True)
+
+    # job list
+    job_list_parser = job_subparsers.add_parser(
+        "list",
+        help="List all jobs",
+    )
+    job_list_parser.add_argument(
+        "--running",
+        "-r",
+        action="store_true",
+        help="Only show running jobs",
+    )
+    job_list_parser.add_argument(
+        "--limit",
+        "-n",
+        type=int,
+        default=None,
+        help="Maximum number of jobs to show",
+    )
+    job_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+
+    # job status
+    job_status_parser = job_subparsers.add_parser(
+        "status",
+        help="Show detailed job status",
+    )
+    job_status_parser.add_argument(
+        "job_id",
+        help="Job ID or prefix",
+    )
+    job_status_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output as JSON",
+    )
+
+    # job logs
+    job_logs_parser = job_subparsers.add_parser(
+        "logs",
+        help="View job output logs",
+    )
+    job_logs_parser.add_argument(
+        "job_id",
+        help="Job ID or prefix",
+    )
+    job_logs_parser.add_argument(
+        "--lines",
+        "-n",
+        type=int,
+        default=None,
+        help="Number of lines to show (tail)",
+    )
+    job_logs_parser.add_argument(
+        "--follow",
+        "-f",
+        action="store_true",
+        help="Follow log output in real-time",
+    )
+
+    # job stop
+    job_stop_parser = job_subparsers.add_parser(
+        "stop",
+        help="Stop a running job",
+    )
+    job_stop_parser.add_argument(
+        "job_id",
+        help="Job ID or prefix",
+    )
+    job_stop_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=5,
+        help="Seconds to wait before force kill (default: 5)",
+    )
+
+    # job clean
+    job_clean_parser = job_subparsers.add_parser(
+        "clean",
+        help="Clean up old job files",
+    )
+    job_clean_parser.add_argument(
+        "--older-than",
+        type=int,
+        default=None,
+        metavar="DAYS",
+        help="Only delete jobs older than this many days",
+    )
+    job_clean_parser.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Show what would be deleted without deleting",
     )
 
     # Board subcommand (with nested subcommands)
@@ -899,6 +1027,48 @@ Configuration:
         if args.board_command == "macros":
             return cmd_macros()
 
+    # Handle job command
+    if args.command == "job":
+        from src.jobs.cli import (
+            cmd_clean,
+            cmd_list,
+            cmd_logs,
+            cmd_status,
+            cmd_stop,
+        )
+
+        if args.job_command == "list":
+            return cmd_list(
+                running_only=args.running,
+                limit=args.limit,
+                json_output=args.json,
+            )
+
+        if args.job_command == "status":
+            return cmd_status(
+                job_id=args.job_id,
+                json_output=args.json,
+            )
+
+        if args.job_command == "logs":
+            return cmd_logs(
+                job_id=args.job_id,
+                lines=args.lines,
+                follow=args.follow,
+            )
+
+        if args.job_command == "stop":
+            return cmd_stop(
+                job_id=args.job_id,
+                timeout=args.timeout,
+            )
+
+        if args.job_command == "clean":
+            return cmd_clean(
+                older_than_days=args.older_than,
+                dry_run=args.dry_run,
+            )
+
     # Handle reconcile command (simple path handling)
     if args.command == "reconcile":
         design_doc = args.design_doc.resolve()
@@ -908,6 +1078,34 @@ Configuration:
     # Handle refine command
     if args.command == "refine":
         workspace = args.workspace.resolve() if args.workspace else find_git_root(Path.cwd())
+
+        # Handle background mode
+        if args.background:
+            from src.jobs import spawn_lxa_command
+
+            # Build the command without --background flag
+            cmd = ["refine", args.pr_url]
+            if args.workspace:
+                cmd.extend(["--workspace", str(args.workspace)])
+            if args.auto_merge:
+                cmd.append("--auto-merge")
+            if args.allow_merge != "acceptable":
+                cmd.extend(["--allow-merge", args.allow_merge])
+            if args.min_iterations != 1:
+                cmd.extend(["--min-iterations", str(args.min_iterations)])
+            if args.max_iterations != 5:
+                cmd.extend(["--max-iterations", str(args.max_iterations)])
+            if args.phase != "auto":
+                cmd.extend(["--phase", args.phase])
+
+            job = spawn_lxa_command(
+                lxa_command=cmd,
+                cwd=workspace,
+                job_name=args.job_name or "refine",
+            )
+            console.print(f"Started job [cyan]{job.id}[/], logs at {job.log_path}")
+            return 0
+
         return run_refine(
             pr_url=args.pr_url,
             workspace=workspace,
@@ -932,6 +1130,43 @@ Configuration:
         config = load_config(workspace)
         design_path = config.get_design_path(keep_design=args.keep_design)
         design_doc = workspace / design_path
+
+    # Handle background mode
+    if args.background:
+        from src.jobs import spawn_lxa_command
+
+        # Build the command without --background flag
+        cmd = ["implement"]
+        if args.design_path:
+            cmd.extend(["--design-path", str(args.design_path)])
+        elif args.design_doc:
+            cmd.append(str(args.design_doc))
+        if args.workspace:
+            cmd.extend(["--workspace", str(args.workspace)])
+        if args.keep_design:
+            cmd.append("--keep-design")
+        if args.loop:
+            cmd.append("--loop")
+        if args.max_iterations != 20:
+            cmd.extend(["--max-iterations", str(args.max_iterations)])
+        if args.refine:
+            cmd.append("--refine")
+        if args.auto_merge:
+            cmd.append("--auto-merge")
+        if args.allow_merge != "acceptable":
+            cmd.extend(["--allow-merge", args.allow_merge])
+        if args.min_iterations != 1:
+            cmd.extend(["--min-iterations", str(args.min_iterations)])
+        if args.max_refine_iterations != 5:
+            cmd.extend(["--max-refine-iterations", str(args.max_refine_iterations)])
+
+        job = spawn_lxa_command(
+            lxa_command=cmd,
+            cwd=workspace,
+            job_name=args.job_name or "implement",
+        )
+        console.print(f"Started job [cyan]{job.id}[/], logs at {job.log_path}")
+        return 0
 
     # Run in loop mode or single execution
     if args.loop:

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -424,6 +424,44 @@ def run_ralph_loop(
     return 0 if loop_result.completed else 1
 
 
+def _filter_background_args(argv: list[str]) -> list[str]:
+    """Filter out --background and --job-name flags from argv.
+
+    This is used to rebuild the command for background execution without
+    the background-specific flags, avoiding fragile manual reconstruction.
+
+    Args:
+        argv: Original command line arguments
+
+    Returns:
+        Filtered arguments without background flags
+    """
+    result = []
+    skip_next = False
+
+    for arg in argv:
+        if skip_next:
+            skip_next = False
+            continue
+
+        # Skip --background and -b flags
+        if arg in ("--background", "-b"):
+            continue
+
+        # Skip --job-name and its value
+        if arg == "--job-name":
+            skip_next = True
+            continue
+
+        # Handle --job-name=value format
+        if arg.startswith("--job-name="):
+            continue
+
+        result.append(arg)
+
+    return result
+
+
 def main(argv: list[str] | None = None) -> int:
     """Main entry point for the CLI.
 
@@ -1083,20 +1121,9 @@ Configuration:
         if args.background:
             from src.jobs import spawn_lxa_command
 
-            # Build the command without --background flag
-            cmd = ["refine", args.pr_url]
-            if args.workspace:
-                cmd.extend(["--workspace", str(args.workspace)])
-            if args.auto_merge:
-                cmd.append("--auto-merge")
-            if args.allow_merge != "acceptable":
-                cmd.extend(["--allow-merge", args.allow_merge])
-            if args.min_iterations != 1:
-                cmd.extend(["--min-iterations", str(args.min_iterations)])
-            if args.max_iterations != 5:
-                cmd.extend(["--max-iterations", str(args.max_iterations)])
-            if args.phase != "auto":
-                cmd.extend(["--phase", args.phase])
+            # Filter out --background and --job-name, keep everything else
+            args_to_use = argv if argv is not None else sys.argv[1:]
+            cmd = _filter_background_args(args_to_use)
 
             job = spawn_lxa_command(
                 lxa_command=cmd,
@@ -1135,30 +1162,9 @@ Configuration:
     if args.background:
         from src.jobs import spawn_lxa_command
 
-        # Build the command without --background flag
-        cmd = ["implement"]
-        if args.design_path:
-            cmd.extend(["--design-path", str(args.design_path)])
-        elif args.design_doc:
-            cmd.append(str(args.design_doc))
-        if args.workspace:
-            cmd.extend(["--workspace", str(args.workspace)])
-        if args.keep_design:
-            cmd.append("--keep-design")
-        if args.loop:
-            cmd.append("--loop")
-        if args.max_iterations != 20:
-            cmd.extend(["--max-iterations", str(args.max_iterations)])
-        if args.refine:
-            cmd.append("--refine")
-        if args.auto_merge:
-            cmd.append("--auto-merge")
-        if args.allow_merge != "acceptable":
-            cmd.extend(["--allow-merge", args.allow_merge])
-        if args.min_iterations != 1:
-            cmd.extend(["--min-iterations", str(args.min_iterations)])
-        if args.max_refine_iterations != 5:
-            cmd.extend(["--max-refine-iterations", str(args.max_refine_iterations)])
+        # Filter out --background and --job-name, keep everything else
+        args_to_use = argv if argv is not None else sys.argv[1:]
+        cmd = _filter_background_args(args_to_use)
 
         job = spawn_lxa_command(
             lxa_command=cmd,

--- a/src/jobs/__init__.py
+++ b/src/jobs/__init__.py
@@ -1,0 +1,23 @@
+"""Background job management for LXA.
+
+This package provides:
+- Detached background execution of long-running commands
+- Job metadata persistence in ~/.lxa/jobs/
+- Job control: list, status, logs, stop, clean
+"""
+
+from src.jobs.executor import read_logs, spawn_detached, spawn_lxa_command
+from src.jobs.manager import JobManager, get_manager
+from src.jobs.models import Job, JobStatus
+from src.jobs.storage import DEFAULT_JOBS_DIR
+
+__all__ = [
+    "DEFAULT_JOBS_DIR",
+    "Job",
+    "JobManager",
+    "JobStatus",
+    "get_manager",
+    "read_logs",
+    "spawn_detached",
+    "spawn_lxa_command",
+]

--- a/src/jobs/cli/__init__.py
+++ b/src/jobs/cli/__init__.py
@@ -1,0 +1,20 @@
+"""Job CLI commands.
+
+This package contains the CLI presentation layer for job commands.
+Each command is a thin wrapper that handles console I/O and delegates
+business logic to the manager layer.
+"""
+
+from src.jobs.cli.clean import cmd_clean
+from src.jobs.cli.list_cmd import cmd_list
+from src.jobs.cli.logs import cmd_logs
+from src.jobs.cli.status import cmd_status
+from src.jobs.cli.stop import cmd_stop
+
+__all__ = [
+    "cmd_clean",
+    "cmd_list",
+    "cmd_logs",
+    "cmd_status",
+    "cmd_stop",
+]

--- a/src/jobs/cli/_helpers.py
+++ b/src/jobs/cli/_helpers.py
@@ -1,0 +1,45 @@
+"""Shared CLI helpers for job commands."""
+
+from rich.console import Console
+from rich.panel import Panel
+
+console = Console()
+
+
+def print_command_header(title: str) -> None:
+    """Print a command header panel.
+
+    Args:
+        title: Command title (e.g., "lxa job list")
+    """
+    console.print(Panel(f"[bold blue]{title}[/]", expand=False))
+
+
+def print_error(message: str, hint: str | None = None) -> None:
+    """Print an error message.
+
+    Args:
+        message: Error message
+        hint: Optional hint for resolution
+    """
+    console.print(f"[red]Error:[/] {message}")
+    if hint:
+        console.print(f"[dim]{hint}[/]")
+
+
+def print_success(message: str) -> None:
+    """Print a success message with checkmark."""
+    console.print(f"[green]✓[/] {message}")
+
+
+def print_info(message: str, dim: bool = False) -> None:
+    """Print an info message.
+
+    Args:
+        message: Message to print
+        dim: Whether to dim the text
+    """
+    if dim:
+        console.print(f"[dim]{message}[/]")
+    else:
+        console.print(message)

--- a/src/jobs/cli/clean.py
+++ b/src/jobs/cli/clean.py
@@ -1,0 +1,81 @@
+"""Job clean command - clean up old job files."""
+
+from rich.console import Console
+
+from src.jobs.cli._helpers import print_command_header, print_info, print_success
+from src.jobs.manager import get_manager
+
+console = Console()
+
+
+def cmd_clean(
+    *,
+    older_than_days: int | None = None,
+    dry_run: bool = False,
+) -> int:
+    """Clean up old job files.
+
+    Args:
+        older_than_days: Only delete jobs older than this many days
+        dry_run: Show what would be deleted without deleting
+
+    Returns:
+        Exit code (0 for success)
+    """
+    print_command_header("lxa job clean")
+
+    manager = get_manager()
+
+    # First, list what would be cleaned
+    jobs = manager.list_jobs(refresh=True, include_terminal=True)
+
+    # Filter to terminal jobs (not running)
+    from datetime import datetime, timedelta
+
+    from src.jobs.models import JobStatus
+
+    to_delete = []
+    cutoff = None
+    if older_than_days is not None:
+        cutoff = datetime.now() - timedelta(days=older_than_days)
+
+    for job in jobs:
+        # Skip running jobs
+        if job.status == JobStatus.RUNNING:
+            continue
+
+        # Skip jobs newer than cutoff
+        if cutoff and job.created_at and job.created_at > cutoff:
+            continue
+
+        to_delete.append(job)
+
+    console.print()
+
+    if not to_delete:
+        print_info("No jobs to clean up.")
+        if older_than_days:
+            console.print(f"[dim](checked for jobs older than {older_than_days} days)[/]")
+        return 0
+
+    if dry_run:
+        console.print(f"[yellow]Would delete {len(to_delete)} job(s):[/]")
+        console.print()
+        for job in to_delete:
+            status_str = job.status.value
+            console.print(f"  [cyan]{job.id}[/] ({status_str})")
+        console.print()
+        console.print("[dim]Run without --dry-run to delete[/]")
+        return 0
+
+    # Actually delete
+    deleted = manager.clean_jobs(older_than_days=older_than_days, include_running=False)
+
+    if deleted:
+        print_success(f"Cleaned up {len(deleted)} job(s)")
+        for job_id in deleted:
+            console.print(f"  [dim]Deleted {job_id}[/]")
+    else:
+        print_info("No jobs deleted.")
+
+    return 0

--- a/src/jobs/cli/list_cmd.py
+++ b/src/jobs/cli/list_cmd.py
@@ -1,0 +1,112 @@
+"""Job list command - list all jobs."""
+
+from rich.console import Console
+from rich.table import Table
+
+from src.jobs.cli._helpers import print_command_header
+from src.jobs.manager import get_manager
+from src.jobs.models import JobStatus
+
+console = Console()
+
+
+def cmd_list(
+    *,
+    running_only: bool = False,
+    limit: int | None = None,
+    json_output: bool = False,
+) -> int:
+    """List all jobs.
+
+    Args:
+        running_only: Only show running jobs
+        limit: Maximum number of jobs to show
+        json_output: Output as JSON
+
+    Returns:
+        Exit code (0 for success)
+    """
+    if not json_output:
+        print_command_header("lxa job list")
+
+    manager = get_manager()
+    jobs = manager.list_jobs(
+        refresh=True,
+        include_terminal=not running_only,
+        limit=limit,
+    )
+
+    if json_output:
+        import json
+
+        data = [j.to_dict() for j in jobs]
+        console.print(json.dumps(data, indent=2))
+        return 0
+
+    if not jobs:
+        console.print("\n[yellow]No jobs found.[/]")
+        console.print("[dim]Start a background job with: lxa implement --background[/]")
+        return 0
+
+    console.print()
+    table = Table(title="Jobs")
+    table.add_column("ID", style="cyan")
+    table.add_column("Command", max_width=40)
+    table.add_column("Status")
+    table.add_column("Duration")
+    table.add_column("Started")
+
+    for job in jobs:
+        # Format status with color
+        status_str = job.status.value
+        if job.status == JobStatus.RUNNING:
+            status_str = f"[green]{status_str}[/]"
+        elif job.status == JobStatus.DONE:
+            status_str = f"[blue]{status_str}[/]"
+        elif job.status == JobStatus.FAILED:
+            status_str = f"[red]{status_str}[/]"
+        elif job.status == JobStatus.STOPPED:
+            status_str = f"[yellow]{status_str}[/]"
+
+        # Format command (truncate if needed)
+        cmd_str = " ".join(job.command)
+        if len(cmd_str) > 40:
+            cmd_str = cmd_str[:37] + "..."
+
+        # Format started time
+        started_str = "-"
+        if job.started_at:
+            from datetime import datetime
+
+            now = datetime.now()
+            delta = now - job.started_at
+            if delta.days > 0:
+                started_str = f"{delta.days}d ago"
+            elif delta.seconds >= 3600:
+                hours = delta.seconds // 3600
+                started_str = f"{hours}h ago"
+            elif delta.seconds >= 60:
+                minutes = delta.seconds // 60
+                started_str = f"{minutes}m ago"
+            else:
+                started_str = "just now"
+
+        table.add_row(
+            job.id,
+            cmd_str,
+            status_str,
+            job.format_duration(),
+            started_str,
+        )
+
+    console.print(table)
+    console.print()
+
+    # Show helpful hints
+    running_count = sum(1 for j in jobs if j.status == JobStatus.RUNNING)
+    if running_count > 0:
+        console.print(f"[dim]{running_count} running job(s)[/]")
+        console.print("[dim]View logs: lxa job logs <id>[/]")
+        console.print("[dim]Stop job: lxa job stop <id>[/]")
+
+    return 0

--- a/src/jobs/cli/logs.py
+++ b/src/jobs/cli/logs.py
@@ -1,0 +1,81 @@
+"""Job logs command - view job output."""
+
+import subprocess
+from pathlib import Path
+
+from rich.console import Console
+
+from src.jobs.cli._helpers import print_command_header, print_error
+from src.jobs.executor import read_logs
+from src.jobs.manager import get_manager
+
+console = Console()
+
+
+def cmd_logs(
+    job_id: str,
+    *,
+    lines: int | None = None,
+    follow: bool = False,
+) -> int:
+    """View logs for a job.
+
+    Args:
+        job_id: Job ID or prefix
+        lines: Number of lines to show (tail)
+        follow: Follow log output in real-time
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    if not follow:
+        print_command_header("lxa job logs")
+
+    manager = get_manager()
+    job = manager.get_job(job_id, refresh=False)
+
+    if job is None:
+        print_error(f"Job not found: {job_id}")
+        console.print("[dim]Use 'lxa job list' to see available jobs[/]")
+        return 1
+
+    log_path = Path(job.log_path)
+
+    if not log_path.exists():
+        print_error(f"Log file not found: {log_path}")
+        return 1
+
+    if follow:
+        # Use tail -f for real-time following
+        console.print(f"[dim]Following logs for {job.id}... (Ctrl+C to stop)[/]")
+        console.print()
+        try:
+            subprocess.run(["tail", "-f", str(log_path)])
+        except KeyboardInterrupt:
+            console.print()
+            console.print("[dim]Stopped following logs[/]")
+        return 0
+
+    # Read log content
+    content = read_logs(job.id, lines=lines)
+
+    if content is None:
+        print_error(f"Could not read log file: {log_path}")
+        return 1
+
+    console.print()
+    console.print(f"[dim]Logs for {job.id}:[/]")
+    console.print()
+
+    if not content.strip():
+        console.print("[dim](empty)[/]")
+    else:
+        # Print with some formatting
+        console.print(content)
+
+    console.print()
+
+    if lines:
+        console.print(f"[dim]Showing last {lines} lines. Use --follow to tail in real-time.[/]")
+
+    return 0

--- a/src/jobs/cli/status.py
+++ b/src/jobs/cli/status.py
@@ -1,0 +1,91 @@
+"""Job status command - show detailed job information."""
+
+from rich.console import Console
+from rich.table import Table
+
+from src.jobs.cli._helpers import print_command_header, print_error
+from src.jobs.manager import get_manager
+from src.jobs.models import JobStatus
+
+console = Console()
+
+
+def cmd_status(job_id: str, *, json_output: bool = False) -> int:
+    """Show detailed status for a job.
+
+    Args:
+        job_id: Job ID or prefix
+        json_output: Output as JSON
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    if not json_output:
+        print_command_header("lxa job status")
+
+    manager = get_manager()
+    job = manager.get_job(job_id, refresh=True)
+
+    if job is None:
+        if json_output:
+            import json
+
+            console.print(json.dumps({"error": f"Job not found: {job_id}"}))
+        else:
+            print_error(f"Job not found: {job_id}")
+            console.print("[dim]Use 'lxa job list' to see available jobs[/]")
+        return 1
+
+    if json_output:
+        import json
+
+        console.print(json.dumps(job.to_dict(), indent=2))
+        return 0
+
+    console.print()
+
+    # Format status with color
+    status_str = job.status.value
+    if job.status == JobStatus.RUNNING:
+        status_str = f"[bold green]{status_str}[/]"
+    elif job.status == JobStatus.DONE:
+        status_str = f"[bold blue]{status_str}[/]"
+    elif job.status == JobStatus.FAILED:
+        status_str = f"[bold red]{status_str}[/]"
+    elif job.status == JobStatus.STOPPED:
+        status_str = f"[bold yellow]{status_str}[/]"
+
+    # Build info table
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Field", style="dim")
+    table.add_column("Value")
+
+    table.add_row("Job", f"[bold cyan]{job.id}[/]")
+    table.add_row("Command", " ".join(job.command))
+    table.add_row("Status", status_str)
+    table.add_row("PID", str(job.pid) if job.pid else "-")
+    table.add_row("Working Dir", job.cwd)
+    table.add_row("Log File", job.log_path)
+    table.add_row("Duration", job.format_duration())
+
+    if job.created_at:
+        table.add_row("Created", job.created_at.strftime("%Y-%m-%d %H:%M:%S"))
+    if job.started_at:
+        table.add_row("Started", job.started_at.strftime("%Y-%m-%d %H:%M:%S"))
+    if job.ended_at:
+        table.add_row("Ended", job.ended_at.strftime("%Y-%m-%d %H:%M:%S"))
+    if job.exit_code is not None:
+        exit_color = "green" if job.exit_code == 0 else "red"
+        table.add_row("Exit Code", f"[{exit_color}]{job.exit_code}[/]")
+
+    console.print(table)
+    console.print()
+
+    # Show helpful hints based on status
+    if job.status == JobStatus.RUNNING:
+        console.print("[dim]View logs: lxa job logs", job.id, "[/]")
+        console.print("[dim]Stop job: lxa job stop", job.id, "[/]")
+    else:
+        console.print("[dim]View logs: lxa job logs", job.id, "[/]")
+
+    return 0

--- a/src/jobs/cli/stop.py
+++ b/src/jobs/cli/stop.py
@@ -1,0 +1,41 @@
+"""Job stop command - stop a running job."""
+
+from rich.console import Console
+
+from src.jobs.cli._helpers import print_command_header, print_error, print_success
+from src.jobs.manager import get_manager
+
+console = Console()
+
+
+def cmd_stop(job_id: str, *, timeout: int = 5) -> int:
+    """Stop a running job.
+
+    Args:
+        job_id: Job ID or prefix
+        timeout: Seconds to wait before force kill
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    print_command_header("lxa job stop")
+
+    manager = get_manager()
+    job = manager.get_job(job_id, refresh=True)
+
+    if job is None:
+        print_error(f"Job not found: {job_id}")
+        console.print("[dim]Use 'lxa job list' to see available jobs[/]")
+        return 1
+
+    console.print()
+    console.print(f"Stopping job [cyan]{job.id}[/]...")
+
+    success, message = manager.stop_job(job.id, timeout=timeout)
+
+    if success:
+        print_success(message)
+        return 0
+    else:
+        print_error(message)
+        return 1

--- a/src/jobs/executor.py
+++ b/src/jobs/executor.py
@@ -55,9 +55,17 @@ def spawn_detached(
 
     log_path = Path(job.log_path)
 
-    # Build the wrapper command that writes exit code on completion
-    # We'll use Python to wrap the command and handle exit code writing
-    wrapper_script = _create_wrapper_script(job.id, jobs_path, command)
+    # Build the wrapper command using the wrapper module
+    # This runs: python -m src.jobs.wrapper <job_id> <jobs_dir> -- <command...>
+    wrapper_command = [
+        sys.executable,
+        "-m",
+        "src.jobs.wrapper",
+        job.id,
+        str(jobs_path),
+        "--",
+        *command,
+    ]
 
     # Start detached process
     # - start_new_session=True creates a new session (like setsid)
@@ -67,9 +75,8 @@ def spawn_detached(
     # handle lifecycle carefully around Popen
     log_file = open(log_path, "w")  # noqa: SIM115
     try:
-        # Use the Python interpreter to run our wrapper script
         proc = subprocess.Popen(
-            [sys.executable, "-c", wrapper_script],
+            wrapper_command,
             cwd=str(cwd),
             stdin=subprocess.DEVNULL,
             stdout=log_file,
@@ -101,63 +108,6 @@ def spawn_detached(
         job.ended_at = datetime.now()
         save_job(job, jobs_path)
         raise
-
-
-def _create_wrapper_script(job_id: str, jobs_dir: Path, command: list[str]) -> str:
-    """Create a Python wrapper script for the background job.
-
-    The wrapper:
-    1. Executes the command
-    2. Captures the exit code
-    3. Updates the job metadata file on completion
-
-    Args:
-        job_id: Job ID for metadata update
-        jobs_dir: Jobs directory path
-        command: Command to execute
-
-    Returns:
-        Python script as a string
-    """
-    # Escape the command list for embedding in Python code
-    import json
-
-    command_json = json.dumps(command)
-    jobs_dir_str = str(jobs_dir)
-
-    return f'''
-import subprocess
-import sys
-import json
-from datetime import datetime
-from pathlib import Path
-
-# Execute the actual command
-command = {command_json}
-try:
-    result = subprocess.run(command, check=False)
-    exit_code = result.returncode
-except Exception as e:
-    print(f"Error executing command: {{e}}", file=sys.stderr)
-    exit_code = 1
-
-# Update job metadata
-jobs_dir = Path({repr(jobs_dir_str)})
-metadata_path = jobs_dir / "{job_id}.json"
-
-if metadata_path.exists():
-    with open(metadata_path) as f:
-        data = json.load(f)
-
-    data["status"] = "done" if exit_code == 0 else "failed"
-    data["exit_code"] = exit_code
-    data["ended_at"] = datetime.now().isoformat()
-
-    with open(metadata_path, "w") as f:
-        json.dump(data, f, indent=2)
-
-sys.exit(exit_code)
-'''
 
 
 def spawn_lxa_command(

--- a/src/jobs/executor.py
+++ b/src/jobs/executor.py
@@ -63,8 +63,8 @@ def spawn_detached(
     # - start_new_session=True creates a new session (like setsid)
     # - stdin from /dev/null to fully detach
     # - stdout/stderr to log file
-    # Note: We don't use context manager because the file handle needs to stay
-    # open for the detached child process
+    # Note: We don't use context manager because we need to handle the file
+    # handle lifecycle carefully around Popen
     log_file = open(log_path, "w")  # noqa: SIM115
     try:
         # Use the Python interpreter to run our wrapper script
@@ -77,6 +77,17 @@ def spawn_detached(
             start_new_session=True,  # This is the key - creates new session
             env={**os.environ},  # Inherit environment
         )
+
+        # Parent can close its copy after child inherits the file descriptor
+        log_file.close()
+
+        # Verify process actually started (didn't immediately fail)
+        if proc.poll() is not None:
+            job.status = JobStatus.FAILED
+            job.exit_code = proc.returncode
+            job.ended_at = datetime.now()
+            save_job(job, jobs_path)
+            return job
 
         job.pid = proc.pid
         save_job(job, jobs_path)

--- a/src/jobs/executor.py
+++ b/src/jobs/executor.py
@@ -1,0 +1,222 @@
+"""Detached job executor.
+
+Handles spawning background processes that:
+- Survive terminal exit (detached from controlling terminal)
+- Redirect stdout/stderr to log file
+- Store PID for later control
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from src.jobs.models import Job, JobStatus
+from src.jobs.storage import ensure_jobs_dir, save_job
+
+
+def spawn_detached(
+    command: list[str],
+    cwd: Path,
+    job_name: str | None = None,
+    jobs_dir: Path | None = None,
+) -> Job:
+    """Spawn a detached background process.
+
+    Creates a new process that:
+    - Is detached from the controlling terminal (survives shell exit)
+    - Has stdout/stderr redirected to a log file
+    - Has its PID stored in job metadata
+
+    Args:
+        command: Command and arguments to run
+        cwd: Working directory for the process
+        job_name: Custom job name (default: derived from command)
+        jobs_dir: Directory for job files (default: ~/.lxa/jobs)
+
+    Returns:
+        Job instance with PID populated
+
+    Raises:
+        OSError: If process creation fails
+    """
+    jobs_path = ensure_jobs_dir(jobs_dir)
+
+    # Create job record
+    job = Job.create(
+        command=command,
+        cwd=cwd,
+        jobs_dir=jobs_path,
+        job_name=job_name,
+    )
+
+    log_path = Path(job.log_path)
+
+    # Build the wrapper command that writes exit code on completion
+    # We'll use Python to wrap the command and handle exit code writing
+    wrapper_script = _create_wrapper_script(job.id, jobs_path, command)
+
+    # Start detached process
+    # - start_new_session=True creates a new session (like setsid)
+    # - stdin from /dev/null to fully detach
+    # - stdout/stderr to log file
+    # Note: We don't use context manager because the file handle needs to stay
+    # open for the detached child process
+    log_file = open(log_path, "w")  # noqa: SIM115
+    try:
+        # Use the Python interpreter to run our wrapper script
+        proc = subprocess.Popen(
+            [sys.executable, "-c", wrapper_script],
+            cwd=str(cwd),
+            stdin=subprocess.DEVNULL,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,  # This is the key - creates new session
+            env={**os.environ},  # Inherit environment
+        )
+
+        job.pid = proc.pid
+        save_job(job, jobs_path)
+
+        return job
+
+    except OSError:
+        # Clean up on failure
+        log_file.close()
+        job.status = JobStatus.FAILED
+        job.ended_at = datetime.now()
+        save_job(job, jobs_path)
+        raise
+
+
+def _create_wrapper_script(job_id: str, jobs_dir: Path, command: list[str]) -> str:
+    """Create a Python wrapper script for the background job.
+
+    The wrapper:
+    1. Executes the command
+    2. Captures the exit code
+    3. Updates the job metadata file on completion
+
+    Args:
+        job_id: Job ID for metadata update
+        jobs_dir: Jobs directory path
+        command: Command to execute
+
+    Returns:
+        Python script as a string
+    """
+    # Escape the command list for embedding in Python code
+    import json
+
+    command_json = json.dumps(command)
+    jobs_dir_str = str(jobs_dir)
+
+    return f'''
+import subprocess
+import sys
+import json
+from datetime import datetime
+from pathlib import Path
+
+# Execute the actual command
+command = {command_json}
+try:
+    result = subprocess.run(command, check=False)
+    exit_code = result.returncode
+except Exception as e:
+    print(f"Error executing command: {{e}}", file=sys.stderr)
+    exit_code = 1
+
+# Update job metadata
+jobs_dir = Path({repr(jobs_dir_str)})
+metadata_path = jobs_dir / "{job_id}.json"
+
+if metadata_path.exists():
+    with open(metadata_path) as f:
+        data = json.load(f)
+
+    data["status"] = "done" if exit_code == 0 else "failed"
+    data["exit_code"] = exit_code
+    data["ended_at"] = datetime.now().isoformat()
+
+    with open(metadata_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+sys.exit(exit_code)
+'''
+
+
+def spawn_lxa_command(
+    lxa_command: list[str],
+    cwd: Path,
+    job_name: str | None = None,
+    jobs_dir: Path | None = None,
+) -> Job:
+    """Spawn an LXA command in the background.
+
+    This is a convenience wrapper that prefixes the command with 'lxa'
+    and uses the Python module invocation for robustness.
+
+    Args:
+        lxa_command: LXA subcommand and arguments (e.g., ["implement", "--loop"])
+        cwd: Working directory
+        job_name: Custom job name
+        jobs_dir: Directory for job files
+
+    Returns:
+        Job instance
+    """
+    # Use module invocation: python -m src <args>
+    # This ensures we use the same Python interpreter and module
+    full_command = [sys.executable, "-m", "src", *lxa_command]
+
+    return spawn_detached(
+        command=full_command,
+        cwd=cwd,
+        job_name=job_name,
+        jobs_dir=jobs_dir,
+    )
+
+
+def read_logs(
+    job_id: str,
+    jobs_dir: Path | None = None,
+    *,
+    lines: int | None = None,
+    follow: bool = False,
+) -> str | None:
+    """Read logs for a job.
+
+    Args:
+        job_id: Job ID
+        jobs_dir: Jobs directory
+        lines: If set, return only the last N lines
+        follow: If True, tail the log (blocking)
+
+    Returns:
+        Log contents, or None if log doesn't exist
+    """
+    jobs_path = ensure_jobs_dir(jobs_dir)
+    log_path = jobs_path / f"{job_id}.log"
+
+    if not log_path.exists():
+        return None
+
+    if follow:
+        # Use subprocess to tail -f
+        import contextlib
+
+        with contextlib.suppress(KeyboardInterrupt):
+            subprocess.run(["tail", "-f", str(log_path)])
+        return None
+
+    content = log_path.read_text()
+
+    if lines is not None:
+        content_lines = content.splitlines()
+        content = "\n".join(content_lines[-lines:])
+
+    return content

--- a/src/jobs/manager.py
+++ b/src/jobs/manager.py
@@ -1,0 +1,285 @@
+"""Job manager for high-level job operations.
+
+Provides the main interface for job management:
+- Listing jobs with status detection
+- Getting job details
+- Stopping running jobs
+- Cleaning up old jobs
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from src.jobs.models import Job, JobStatus
+from src.jobs.storage import (
+    delete_job,
+    ensure_jobs_dir,
+    find_job_by_prefix,
+    list_jobs,
+    load_job,
+    save_job,
+)
+
+
+def is_process_running(pid: int) -> bool:
+    """Check if a process with the given PID is running.
+
+    Args:
+        pid: Process ID to check
+
+    Returns:
+        True if process exists, False otherwise
+    """
+    try:
+        # Signal 0 doesn't send anything but checks if process exists
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we don't have permission to signal it
+        return True
+
+
+def refresh_job_status(job: Job, jobs_dir: Path | None = None) -> Job:
+    """Refresh job status by checking if PID is still running.
+
+    If the job was marked as RUNNING but the process is no longer running,
+    update the status to FAILED (since we don't know the exit code).
+
+    Args:
+        job: Job to refresh
+        jobs_dir: Jobs directory for saving updates
+
+    Returns:
+        Updated job
+    """
+    if job.status != JobStatus.RUNNING:
+        return job
+
+    if job.pid is None:
+        return job
+
+    if not is_process_running(job.pid):
+        # Process died without proper cleanup
+        job.status = JobStatus.FAILED
+        job.ended_at = datetime.now()
+        save_job(job, jobs_dir)
+
+    return job
+
+
+class JobManager:
+    """High-level interface for job management."""
+
+    def __init__(self, jobs_dir: Path | None = None):
+        """Initialize job manager.
+
+        Args:
+            jobs_dir: Custom jobs directory (default: ~/.lxa/jobs)
+        """
+        self.jobs_dir = ensure_jobs_dir(jobs_dir)
+
+    def list_jobs(
+        self,
+        *,
+        refresh: bool = True,
+        include_terminal: bool = True,
+        limit: int | None = None,
+    ) -> list[Job]:
+        """List all jobs.
+
+        Args:
+            refresh: Whether to check PID status for running jobs
+            include_terminal: Whether to include completed/failed/stopped jobs
+            limit: Maximum number of jobs to return
+
+        Returns:
+            List of jobs, sorted by created_at descending
+        """
+        jobs = list_jobs(self.jobs_dir)
+
+        if refresh:
+            jobs = [refresh_job_status(job, self.jobs_dir) for job in jobs]
+
+        if not include_terminal:
+            jobs = [j for j in jobs if not j.status.is_terminal()]
+
+        if limit:
+            jobs = jobs[:limit]
+
+        return jobs
+
+    def get_job(self, job_id: str, *, refresh: bool = True) -> Job | None:
+        """Get a job by ID or prefix.
+
+        Args:
+            job_id: Job ID or unique prefix
+            refresh: Whether to check PID status
+
+        Returns:
+            Job if found, None otherwise
+        """
+        # Try exact match first
+        job = load_job(job_id, self.jobs_dir)
+
+        # Try prefix match if exact fails
+        if job is None:
+            job = find_job_by_prefix(job_id, self.jobs_dir)
+
+        if job and refresh:
+            job = refresh_job_status(job, self.jobs_dir)
+
+        return job
+
+    def stop_job(self, job_id: str, *, timeout: int = 5) -> tuple[bool, str]:
+        """Stop a running job.
+
+        Sends SIGTERM first, then SIGKILL after timeout if needed.
+
+        Args:
+            job_id: Job ID or prefix
+            timeout: Seconds to wait before SIGKILL
+
+        Returns:
+            Tuple of (success, message)
+        """
+        job = self.get_job(job_id, refresh=True)
+
+        if job is None:
+            return False, f"Job not found: {job_id}"
+
+        if job.status.is_terminal():
+            return False, f"Job {job.id} is not running (status: {job.status.value})"
+
+        if job.pid is None:
+            return False, f"Job {job.id} has no PID"
+
+        try:
+            # Try graceful termination first
+            os.kill(job.pid, signal.SIGTERM)
+
+            # Wait for process to exit
+            import time
+
+            for _ in range(timeout * 10):  # Check every 100ms
+                time.sleep(0.1)
+                if not is_process_running(job.pid):
+                    break
+
+            # If still running, force kill
+            if is_process_running(job.pid):
+                os.kill(job.pid, signal.SIGKILL)
+                time.sleep(0.1)
+
+            # Update job status
+            job.status = JobStatus.STOPPED
+            job.ended_at = datetime.now()
+            save_job(job, self.jobs_dir)
+
+            return True, f"Stopped job {job.id}"
+
+        except ProcessLookupError:
+            # Process already exited
+            job.status = JobStatus.STOPPED
+            job.ended_at = datetime.now()
+            save_job(job, self.jobs_dir)
+            return True, f"Job {job.id} already stopped"
+
+        except PermissionError:
+            return False, f"Permission denied stopping job {job.id}"
+
+    def clean_jobs(
+        self,
+        *,
+        older_than_days: int | None = None,
+        include_running: bool = False,
+    ) -> list[str]:
+        """Clean up old job files.
+
+        Args:
+            older_than_days: Only delete jobs older than this many days
+            include_running: Whether to delete running jobs (dangerous)
+
+        Returns:
+            List of deleted job IDs
+        """
+        jobs = self.list_jobs(refresh=True, include_terminal=True)
+        deleted = []
+
+        cutoff = None
+        if older_than_days is not None:
+            cutoff = datetime.now() - timedelta(days=older_than_days)
+
+        for job in jobs:
+            # Skip running jobs unless explicitly included
+            if job.status == JobStatus.RUNNING and not include_running:
+                continue
+
+            # Skip jobs newer than cutoff
+            if cutoff and job.created_at and job.created_at > cutoff:
+                continue
+
+            if delete_job(job.id, self.jobs_dir):
+                deleted.append(job.id)
+
+        return deleted
+
+    def update_job(
+        self,
+        job_id: str,
+        *,
+        status: JobStatus | None = None,
+        pid: int | None = None,
+        exit_code: int | None = None,
+        ended_at: datetime | None = None,
+    ) -> Job | None:
+        """Update a job's fields.
+
+        Args:
+            job_id: Job ID
+            status: New status
+            pid: New PID
+            exit_code: New exit code
+            ended_at: New ended_at timestamp
+
+        Returns:
+            Updated job, or None if not found
+        """
+        job = load_job(job_id, self.jobs_dir)
+        if job is None:
+            return None
+
+        if status is not None:
+            job.status = status
+        if pid is not None:
+            job.pid = pid
+        if exit_code is not None:
+            job.exit_code = exit_code
+        if ended_at is not None:
+            job.ended_at = ended_at
+
+        save_job(job, self.jobs_dir)
+        return job
+
+    def running_count(self) -> int:
+        """Get count of running jobs."""
+        jobs = self.list_jobs(refresh=True, include_terminal=False)
+        return len(jobs)
+
+
+# Module-level convenience function
+def get_manager(jobs_dir: Path | None = None) -> JobManager:
+    """Get a JobManager instance.
+
+    Args:
+        jobs_dir: Custom jobs directory
+
+    Returns:
+        JobManager instance
+    """
+    return JobManager(jobs_dir)

--- a/src/jobs/manager.py
+++ b/src/jobs/manager.py
@@ -51,6 +51,12 @@ def refresh_job_status(job: Job, jobs_dir: Path | None = None) -> Job:
     If the job was marked as RUNNING but the process is no longer running,
     update the status to FAILED (since we don't know the exit code).
 
+    Note: Known limitation - if a job's process completes successfully but the
+    wrapper crashes before updating metadata (e.g., power loss, OOM kill), this
+    function will incorrectly mark the job as FAILED since the PID is gone but
+    status is still RUNNING. This is a pragmatic tradeoff vs. more complex
+    two-phase commit or separate status-writer processes.
+
     Args:
         job: Job to refresh
         jobs_dir: Jobs directory for saving updates

--- a/src/jobs/models.py
+++ b/src/jobs/models.py
@@ -26,6 +26,27 @@ class JobStatus(str, Enum):
         return self in (JobStatus.DONE, JobStatus.FAILED, JobStatus.STOPPED)
 
 
+def sanitize_job_name(name: str) -> str:
+    """Sanitize job name to prevent path traversal and invalid filenames.
+
+    Args:
+        name: Raw job name from user input or command
+
+    Returns:
+        Sanitized name safe for use in file paths
+    """
+    # Remove path separators and traversal patterns
+    sanitized = name.replace("/", "-").replace("\\", "-").replace("..", "")
+    # Remove other problematic characters for filenames
+    sanitized = sanitized.replace("\x00", "").replace(":", "-")
+    # Collapse multiple dashes and strip leading/trailing
+    while "--" in sanitized:
+        sanitized = sanitized.replace("--", "-")
+    sanitized = sanitized.strip("-")
+    # Ensure non-empty
+    return sanitized or "job"
+
+
 def generate_job_id(name: str) -> str:
     """Generate a unique job ID with format {name}-{hash}.
 
@@ -35,8 +56,10 @@ def generate_job_id(name: str) -> str:
     Returns:
         Unique job ID like "implement-a3f2b1c" or "my-feature-x9y8z7w"
     """
+    # Sanitize name to prevent path traversal attacks
+    safe_name = sanitize_job_name(name)
     hash_suffix = uuid.uuid4().hex[:7]
-    return f"{name}-{hash_suffix}"
+    return f"{safe_name}-{hash_suffix}"
 
 
 @dataclass

--- a/src/jobs/models.py
+++ b/src/jobs/models.py
@@ -1,0 +1,172 @@
+"""Job data models.
+
+Defines the Job dataclass and JobStatus enum for representing
+background job state.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+
+
+class JobStatus(str, Enum):
+    """Status of a background job."""
+
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    STOPPED = "stopped"
+
+    def is_terminal(self) -> bool:
+        """Return True if this is a terminal state (job is no longer running)."""
+        return self in (JobStatus.DONE, JobStatus.FAILED, JobStatus.STOPPED)
+
+
+def generate_job_id(name: str) -> str:
+    """Generate a unique job ID with format {name}-{hash}.
+
+    Args:
+        name: Base name for the job (e.g., "implement", "refine", custom name)
+
+    Returns:
+        Unique job ID like "implement-a3f2b1c" or "my-feature-x9y8z7w"
+    """
+    hash_suffix = uuid.uuid4().hex[:7]
+    return f"{name}-{hash_suffix}"
+
+
+@dataclass
+class Job:
+    """Represents a background job.
+
+    Attributes:
+        id: Unique job identifier (format: {name}-{hash})
+        command: Command arguments (e.g., ["implement", "--loop"])
+        cwd: Working directory where the job runs
+        pid: Process ID of the running job (None if not started or waiting)
+        status: Current job status
+        log_path: Path to the job's log file
+        created_at: When the job was created
+        started_at: When the job started running (None if not started)
+        ended_at: When the job finished (None if still running)
+        exit_code: Exit code (None if still running)
+    """
+
+    id: str
+    command: list[str]
+    cwd: str
+    log_path: str
+    pid: int | None = None
+    status: JobStatus = JobStatus.RUNNING
+    created_at: datetime = field(default_factory=datetime.now)
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+    exit_code: int | None = None
+
+    @classmethod
+    def create(
+        cls,
+        command: list[str],
+        cwd: Path,
+        jobs_dir: Path,
+        job_name: str | None = None,
+    ) -> Job:
+        """Create a new job with generated ID and paths.
+
+        Args:
+            command: Command arguments to run
+            cwd: Working directory
+            jobs_dir: Directory for job files (e.g., ~/.lxa/jobs)
+            job_name: Custom job name (default: derived from command)
+
+        Returns:
+            New Job instance with generated ID and log path
+        """
+        # Derive name from command if not provided
+        name = job_name or command[0] if command else "job"
+        job_id = generate_job_id(name)
+        log_path = jobs_dir / f"{job_id}.log"
+
+        now = datetime.now()
+        return cls(
+            id=job_id,
+            command=command,
+            cwd=str(cwd),
+            log_path=str(log_path),
+            status=JobStatus.RUNNING,
+            created_at=now,
+            started_at=now,
+        )
+
+    def to_dict(self) -> dict:
+        """Convert job to dictionary for JSON serialization."""
+        return {
+            "id": self.id,
+            "command": self.command,
+            "cwd": self.cwd,
+            "pid": self.pid,
+            "status": self.status.value,
+            "log_path": self.log_path,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "ended_at": self.ended_at.isoformat() if self.ended_at else None,
+            "exit_code": self.exit_code,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Job:
+        """Create job from dictionary (JSON deserialization)."""
+        return cls(
+            id=data["id"],
+            command=data["command"],
+            cwd=data["cwd"],
+            pid=data.get("pid"),
+            status=JobStatus(data["status"]),
+            log_path=data["log_path"],
+            created_at=datetime.fromisoformat(data["created_at"])
+            if data.get("created_at")
+            else datetime.now(),
+            started_at=datetime.fromisoformat(data["started_at"])
+            if data.get("started_at")
+            else None,
+            ended_at=datetime.fromisoformat(data["ended_at"]) if data.get("ended_at") else None,
+            exit_code=data.get("exit_code"),
+        )
+
+    def metadata_path(self, jobs_dir: Path) -> Path:
+        """Get the path to this job's metadata file."""
+        return jobs_dir / f"{self.id}.json"
+
+    @property
+    def duration(self) -> float | None:
+        """Get job duration in seconds.
+
+        Returns:
+            Duration in seconds, or None if job hasn't started
+        """
+        if not self.started_at:
+            return None
+
+        end = self.ended_at or datetime.now()
+        return (end - self.started_at).total_seconds()
+
+    def format_duration(self) -> str:
+        """Format duration as human-readable string."""
+        seconds = self.duration
+        if seconds is None:
+            return "-"
+
+        if seconds < 60:
+            return f"{int(seconds)}s"
+        elif seconds < 3600:
+            minutes = int(seconds // 60)
+            secs = int(seconds % 60)
+            return f"{minutes}m {secs}s"
+        else:
+            hours = int(seconds // 3600)
+            minutes = int((seconds % 3600) // 60)
+            return f"{hours}h {minutes}m"

--- a/src/jobs/storage.py
+++ b/src/jobs/storage.py
@@ -1,0 +1,149 @@
+"""Job storage operations.
+
+Handles reading and writing job metadata to ~/.lxa/jobs/ directory.
+Each job has two files:
+- {job_id}.json - Job metadata (status, timestamps, etc.)
+- {job_id}.log - stdout/stderr output
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.jobs.models import Job
+
+DEFAULT_JOBS_DIR = Path.home() / ".lxa" / "jobs"
+
+
+def ensure_jobs_dir(jobs_dir: Path | None = None) -> Path:
+    """Ensure the jobs directory exists.
+
+    Args:
+        jobs_dir: Custom jobs directory (default: ~/.lxa/jobs)
+
+    Returns:
+        Path to the jobs directory
+    """
+    path = jobs_dir or DEFAULT_JOBS_DIR
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def save_job(job: Job, jobs_dir: Path | None = None) -> None:
+    """Save job metadata to JSON file.
+
+    Args:
+        job: Job to save
+        jobs_dir: Custom jobs directory (default: ~/.lxa/jobs)
+    """
+    path = ensure_jobs_dir(jobs_dir)
+    metadata_path = path / f"{job.id}.json"
+
+    with open(metadata_path, "w") as f:
+        json.dump(job.to_dict(), f, indent=2)
+
+
+def load_job(job_id: str, jobs_dir: Path | None = None) -> Job | None:
+    """Load job metadata from JSON file.
+
+    Args:
+        job_id: Job ID to load
+        jobs_dir: Custom jobs directory (default: ~/.lxa/jobs)
+
+    Returns:
+        Job if found, None otherwise
+    """
+    path = ensure_jobs_dir(jobs_dir)
+    metadata_path = path / f"{job_id}.json"
+
+    if not metadata_path.exists():
+        return None
+
+    with open(metadata_path) as f:
+        data = json.load(f)
+        return Job.from_dict(data)
+
+
+def list_jobs(jobs_dir: Path | None = None) -> list[Job]:
+    """List all jobs from the jobs directory.
+
+    Args:
+        jobs_dir: Custom jobs directory (default: ~/.lxa/jobs)
+
+    Returns:
+        List of all jobs, sorted by created_at descending (newest first)
+    """
+    path = ensure_jobs_dir(jobs_dir)
+
+    jobs = []
+    for metadata_file in path.glob("*.json"):
+        with open(metadata_file) as f:
+            data = json.load(f)
+            jobs.append(Job.from_dict(data))
+
+    # Sort by created_at descending (newest first)
+    jobs.sort(key=lambda j: j.created_at or j.started_at, reverse=True)
+    return jobs
+
+
+def delete_job(job_id: str, jobs_dir: Path | None = None) -> bool:
+    """Delete job metadata and log files.
+
+    Args:
+        job_id: Job ID to delete
+        jobs_dir: Custom jobs directory (default: ~/.lxa/jobs)
+
+    Returns:
+        True if job was deleted, False if not found
+    """
+    path = ensure_jobs_dir(jobs_dir)
+    metadata_path = path / f"{job_id}.json"
+    log_path = path / f"{job_id}.log"
+
+    deleted = False
+    if metadata_path.exists():
+        metadata_path.unlink()
+        deleted = True
+    if log_path.exists():
+        log_path.unlink()
+        deleted = True
+
+    return deleted
+
+
+def find_job_by_prefix(prefix: str, jobs_dir: Path | None = None) -> Job | None:
+    """Find a job by ID prefix (for convenience).
+
+    Args:
+        prefix: Job ID prefix (e.g., "implement-a3f" matches "implement-a3f2b1c")
+        jobs_dir: Custom jobs directory (default: ~/.lxa/jobs)
+
+    Returns:
+        Matching job if exactly one found, None otherwise
+    """
+    path = ensure_jobs_dir(jobs_dir)
+
+    matches = []
+    for metadata_file in path.glob(f"{prefix}*.json"):
+        job_id = metadata_file.stem
+        matches.append(job_id)
+
+    if len(matches) == 1:
+        return load_job(matches[0], jobs_dir)
+
+    return None
+
+
+def get_log_path(job_id: str, jobs_dir: Path | None = None) -> Path:
+    """Get the log file path for a job.
+
+    Args:
+        job_id: Job ID
+        jobs_dir: Custom jobs directory (default: ~/.lxa/jobs)
+
+    Returns:
+        Path to the log file (may not exist yet)
+    """
+    path = ensure_jobs_dir(jobs_dir)
+    return path / f"{job_id}.log"

--- a/src/jobs/wrapper.py
+++ b/src/jobs/wrapper.py
@@ -1,0 +1,109 @@
+"""Job wrapper module for detached process execution.
+
+This module is executed by detached background processes to:
+1. Run the actual command
+2. Capture the exit code
+3. Update the job metadata file on completion
+
+Usage:
+    python -m src.jobs.wrapper <job_id> <jobs_dir> -- <command...>
+
+This is a standalone entry point designed to be run by spawn_detached().
+Having this as a proper module (vs. embedded string) makes the wrapper
+logic testable and maintainable.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def update_job_metadata(job_id: str, jobs_dir: Path, exit_code: int) -> None:
+    """Update job metadata file with completion status.
+
+    Args:
+        job_id: Job ID
+        jobs_dir: Path to jobs directory
+        exit_code: Exit code from the command
+    """
+    metadata_path = jobs_dir / f"{job_id}.json"
+
+    if not metadata_path.exists():
+        print(f"Warning: Job metadata not found: {metadata_path}", file=sys.stderr)
+        return
+
+    with open(metadata_path) as f:
+        data = json.load(f)
+
+    data["status"] = "done" if exit_code == 0 else "failed"
+    data["exit_code"] = exit_code
+    data["ended_at"] = datetime.now().isoformat()
+
+    with open(metadata_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def run_job(job_id: str, jobs_dir: Path, command: list[str]) -> int:
+    """Run a job command and update metadata on completion.
+
+    Args:
+        job_id: Job ID for metadata updates
+        jobs_dir: Path to jobs directory
+        command: Command and arguments to execute
+
+    Returns:
+        Exit code from the command
+    """
+    try:
+        result = subprocess.run(command, check=False)
+        exit_code = result.returncode
+    except Exception as e:
+        print(f"Error executing command: {e}", file=sys.stderr)
+        exit_code = 1
+
+    update_job_metadata(job_id, jobs_dir, exit_code)
+    return exit_code
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point for wrapper module.
+
+    Args:
+        argv: Command line arguments (for testing)
+
+    Returns:
+        Exit code
+    """
+    args = argv if argv is not None else sys.argv[1:]
+
+    if len(args) < 3:
+        print(
+            "Usage: python -m src.jobs.wrapper <job_id> <jobs_dir> -- <command...>",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Find the -- separator
+    try:
+        sep_index = args.index("--")
+    except ValueError:
+        print("Error: Missing -- separator before command", file=sys.stderr)
+        return 1
+
+    job_id = args[0]
+    jobs_dir = Path(args[1])
+    command = args[sep_index + 1 :]
+
+    if not command:
+        print("Error: No command specified after --", file=sys.stderr)
+        return 1
+
+    return run_job(job_id, jobs_dir, command)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/jobs/__init__.py
+++ b/tests/jobs/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the jobs package."""

--- a/tests/jobs/test_executor.py
+++ b/tests/jobs/test_executor.py
@@ -1,0 +1,211 @@
+"""Tests for job executor."""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+from src.jobs.executor import read_logs, spawn_detached
+from src.jobs.manager import is_process_running
+from src.jobs.models import JobStatus
+from src.jobs.storage import load_job
+
+
+class TestSpawnDetached:
+    """Tests for spawn_detached function."""
+
+    def test_spawns_process(self, tmp_path: Path):
+        """Test spawns a detached process."""
+        job = spawn_detached(
+            command=["echo", "hello"],
+            cwd=tmp_path,
+            job_name="echo-test",
+            jobs_dir=tmp_path,
+        )
+
+        assert job.id.startswith("echo-test-")
+        assert job.pid is not None
+        assert job.status == JobStatus.RUNNING
+
+    def test_process_survives(self, tmp_path: Path):
+        """Test spawned process runs independently."""
+        # Start a process that will take a moment
+        job = spawn_detached(
+            command=[sys.executable, "-c", "import time; time.sleep(2); print('done')"],
+            cwd=tmp_path,
+            job_name="sleep-test",
+            jobs_dir=tmp_path,
+        )
+
+        # Process should be running
+        assert job.pid is not None
+        assert is_process_running(job.pid)
+
+        # Wait for it to complete
+        time.sleep(3)
+
+        # Check that it updated metadata
+        updated = load_job(job.id, tmp_path)
+        assert updated is not None
+        assert updated.status in (JobStatus.DONE, JobStatus.FAILED)
+        assert updated.exit_code is not None
+
+    def test_writes_to_log(self, tmp_path: Path):
+        """Test output is written to log file."""
+        job = spawn_detached(
+            command=[sys.executable, "-c", "print('hello world')"],
+            cwd=tmp_path,
+            job_name="log-test",
+            jobs_dir=tmp_path,
+        )
+
+        # Wait for process to complete
+        time.sleep(1)
+
+        log_path = tmp_path / f"{job.id}.log"
+        assert log_path.exists()
+
+        content = log_path.read_text()
+        assert "hello world" in content
+
+    def test_captures_stderr(self, tmp_path: Path):
+        """Test stderr is also captured."""
+        job = spawn_detached(
+            command=[
+                sys.executable,
+                "-c",
+                "import sys; print('error message', file=sys.stderr)",
+            ],
+            cwd=tmp_path,
+            job_name="stderr-test",
+            jobs_dir=tmp_path,
+        )
+
+        time.sleep(1)
+
+        log_path = tmp_path / f"{job.id}.log"
+        content = log_path.read_text()
+        assert "error message" in content
+
+    def test_updates_status_on_success(self, tmp_path: Path):
+        """Test job status is updated to DONE on success."""
+        job = spawn_detached(
+            command=[sys.executable, "-c", "print('ok')"],
+            cwd=tmp_path,
+            job_name="success-test",
+            jobs_dir=tmp_path,
+        )
+
+        time.sleep(1)
+
+        updated = load_job(job.id, tmp_path)
+        assert updated is not None
+        assert updated.status == JobStatus.DONE
+        assert updated.exit_code == 0
+        assert updated.ended_at is not None
+
+    def test_updates_status_on_failure(self, tmp_path: Path):
+        """Test job status is updated to FAILED on error."""
+        job = spawn_detached(
+            command=[sys.executable, "-c", "import sys; sys.exit(42)"],
+            cwd=tmp_path,
+            job_name="fail-test",
+            jobs_dir=tmp_path,
+        )
+
+        time.sleep(1)
+
+        updated = load_job(job.id, tmp_path)
+        assert updated is not None
+        assert updated.status == JobStatus.FAILED
+        assert updated.exit_code == 42
+
+    def test_working_directory(self, tmp_path: Path):
+        """Test process runs in specified working directory."""
+        # Create a marker file to verify cwd
+        marker = tmp_path / "marker.txt"
+        marker.write_text("test")
+
+        job = spawn_detached(
+            command=[sys.executable, "-c", "import os; print(os.getcwd())"],
+            cwd=tmp_path,
+            job_name="cwd-test",
+            jobs_dir=tmp_path,
+        )
+
+        time.sleep(1)
+
+        log_path = tmp_path / f"{job.id}.log"
+        content = log_path.read_text()
+        assert str(tmp_path) in content
+
+    def test_inherits_environment(self, tmp_path: Path):
+        """Test process inherits environment variables."""
+        # Set a test env var
+        os.environ["TEST_JOB_VAR"] = "test_value_123"
+
+        try:
+            job = spawn_detached(
+                command=[
+                    sys.executable,
+                    "-c",
+                    "import os; print(os.environ.get('TEST_JOB_VAR', 'NOT_SET'))",
+                ],
+                cwd=tmp_path,
+                job_name="env-test",
+                jobs_dir=tmp_path,
+            )
+
+            time.sleep(1)
+
+            log_path = tmp_path / f"{job.id}.log"
+            content = log_path.read_text()
+            assert "test_value_123" in content
+        finally:
+            del os.environ["TEST_JOB_VAR"]
+
+    def test_default_job_name(self, tmp_path: Path):
+        """Test job name is derived from command."""
+        job = spawn_detached(
+            command=["echo", "hi"],
+            cwd=tmp_path,
+            jobs_dir=tmp_path,
+        )
+
+        assert job.id.startswith("echo-")
+
+
+class TestReadLogs:
+    """Tests for read_logs function."""
+
+    def test_read_full_log(self, tmp_path: Path):
+        """Test reading entire log file."""
+        log_path = tmp_path / "test-abc1234.log"
+        log_path.write_text("line 1\nline 2\nline 3\n")
+
+        content = read_logs("test-abc1234", tmp_path)
+
+        assert content == "line 1\nline 2\nline 3\n"
+
+    def test_read_last_lines(self, tmp_path: Path):
+        """Test reading last N lines."""
+        log_path = tmp_path / "test-lines.log"
+        log_path.write_text("line 1\nline 2\nline 3\nline 4\nline 5\n")
+
+        content = read_logs("test-lines", tmp_path, lines=2)
+
+        assert content == "line 4\nline 5"
+
+    def test_log_not_found(self, tmp_path: Path):
+        """Test returns None for missing log."""
+        content = read_logs("nonexistent", tmp_path)
+        assert content is None
+
+    def test_empty_log(self, tmp_path: Path):
+        """Test reading empty log file."""
+        log_path = tmp_path / "test-empty.log"
+        log_path.write_text("")
+
+        content = read_logs("test-empty", tmp_path)
+
+        assert content == ""

--- a/tests/jobs/test_manager.py
+++ b/tests/jobs/test_manager.py
@@ -1,0 +1,407 @@
+"""Tests for job manager."""
+
+import os
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src.jobs.manager import JobManager, is_process_running, refresh_job_status
+from src.jobs.models import Job, JobStatus
+from src.jobs.storage import save_job
+
+
+class TestIsProcessRunning:
+    """Tests for is_process_running function."""
+
+    def test_current_process(self):
+        """Test returns True for current process."""
+        assert is_process_running(os.getpid())
+
+    def test_nonexistent_process(self):
+        """Test returns False for nonexistent PID."""
+        # Use a very high PID that's unlikely to exist
+        assert not is_process_running(999999999)
+
+    def test_init_process(self):
+        """Test returns True for init process (PID 1)."""
+        # This might fail on some systems without permission
+        result = is_process_running(1)
+        # Just verify it doesn't raise
+        assert isinstance(result, bool)
+
+
+class TestRefreshJobStatus:
+    """Tests for refresh_job_status function."""
+
+    def test_running_job_with_valid_pid(self, tmp_path: Path):
+        """Test running job with valid PID stays running."""
+        job = Job(
+            id="test-running",
+            command=["sleep"],
+            cwd="/test",
+            log_path=str(tmp_path / "test.log"),
+            pid=os.getpid(),  # Use current process as valid PID
+            status=JobStatus.RUNNING,
+            started_at=datetime.now(),
+        )
+        save_job(job, tmp_path)
+
+        result = refresh_job_status(job, tmp_path)
+
+        assert result.status == JobStatus.RUNNING
+
+    def test_running_job_with_dead_pid(self, tmp_path: Path):
+        """Test running job with dead PID becomes failed."""
+        job = Job(
+            id="test-dead",
+            command=["sleep"],
+            cwd="/test",
+            log_path=str(tmp_path / "test.log"),
+            pid=999999999,  # Nonexistent PID
+            status=JobStatus.RUNNING,
+            started_at=datetime.now(),
+        )
+        save_job(job, tmp_path)
+
+        result = refresh_job_status(job, tmp_path)
+
+        assert result.status == JobStatus.FAILED
+        assert result.ended_at is not None
+
+    def test_terminal_job_unchanged(self, tmp_path: Path):
+        """Test terminal job status is not changed."""
+        job = Job(
+            id="test-done",
+            command=["echo"],
+            cwd="/test",
+            log_path=str(tmp_path / "test.log"),
+            pid=999999999,  # Dead PID, but job is done
+            status=JobStatus.DONE,
+            started_at=datetime.now(),
+            ended_at=datetime.now(),
+        )
+        save_job(job, tmp_path)
+
+        result = refresh_job_status(job, tmp_path)
+
+        assert result.status == JobStatus.DONE
+
+    def test_no_pid(self, tmp_path: Path):
+        """Test job with no PID is unchanged."""
+        job = Job(
+            id="test-nopid",
+            command=["echo"],
+            cwd="/test",
+            log_path=str(tmp_path / "test.log"),
+            pid=None,
+            status=JobStatus.RUNNING,
+            started_at=datetime.now(),
+        )
+
+        result = refresh_job_status(job, tmp_path)
+
+        assert result.status == JobStatus.RUNNING
+
+
+class TestJobManager:
+    """Tests for JobManager class."""
+
+    @pytest.fixture
+    def manager(self, tmp_path: Path) -> JobManager:
+        """Create a JobManager with temp directory."""
+        return JobManager(tmp_path)
+
+    def test_list_jobs_empty(self, manager: JobManager):
+        """Test list_jobs returns empty list."""
+        jobs = manager.list_jobs()
+        assert jobs == []
+
+    def test_list_jobs(self, manager: JobManager):
+        """Test list_jobs returns all jobs."""
+        job1 = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="job1",
+        )
+        job2 = Job.create(
+            command=["refine"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="job2",
+        )
+        save_job(job1, manager.jobs_dir)
+        save_job(job2, manager.jobs_dir)
+
+        jobs = manager.list_jobs()
+
+        assert len(jobs) == 2
+
+    def test_list_jobs_exclude_terminal(self, manager: JobManager):
+        """Test list_jobs can exclude terminal jobs."""
+        job_running = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="running",
+        )
+        job_running.pid = os.getpid()  # Use valid PID
+
+        job_done = Job.create(
+            command=["done"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="done",
+        )
+        job_done.status = JobStatus.DONE
+
+        save_job(job_running, manager.jobs_dir)
+        save_job(job_done, manager.jobs_dir)
+
+        jobs = manager.list_jobs(include_terminal=False)
+
+        assert len(jobs) == 1
+        assert jobs[0].id == job_running.id
+
+    def test_list_jobs_limit(self, manager: JobManager):
+        """Test list_jobs respects limit."""
+        for i in range(5):
+            job = Job.create(
+                command=["implement"],
+                cwd=Path("/test"),
+                jobs_dir=manager.jobs_dir,
+                job_name=f"job{i}",
+            )
+            save_job(job, manager.jobs_dir)
+
+        jobs = manager.list_jobs(limit=3)
+
+        assert len(jobs) == 3
+
+    def test_get_job_exact(self, manager: JobManager):
+        """Test get_job by exact ID."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="findme",
+        )
+        save_job(job, manager.jobs_dir)
+
+        result = manager.get_job(job.id)
+
+        assert result is not None
+        assert result.id == job.id
+
+    def test_get_job_prefix(self, manager: JobManager):
+        """Test get_job by prefix."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="unique-prefix",
+        )
+        save_job(job, manager.jobs_dir)
+
+        result = manager.get_job("unique-prefix-")
+
+        assert result is not None
+        assert result.id == job.id
+
+    def test_get_job_not_found(self, manager: JobManager):
+        """Test get_job returns None for missing job."""
+        result = manager.get_job("nonexistent-1234567")
+        assert result is None
+
+    def test_stop_job_not_found(self, manager: JobManager):
+        """Test stop_job returns error for missing job."""
+        success, message = manager.stop_job("nonexistent")
+        assert not success
+        assert "not found" in message.lower()
+
+    def test_stop_job_already_done(self, manager: JobManager):
+        """Test stop_job returns error for terminal job."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="done-job",
+        )
+        job.status = JobStatus.DONE
+        save_job(job, manager.jobs_dir)
+
+        success, message = manager.stop_job(job.id)
+
+        assert not success
+        assert "not running" in message.lower()
+
+    def test_stop_job_no_pid(self, manager: JobManager):
+        """Test stop_job returns error for job without PID."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="no-pid",
+        )
+        job.pid = None
+        save_job(job, manager.jobs_dir)
+
+        success, message = manager.stop_job(job.id)
+
+        assert not success
+        assert "no pid" in message.lower()
+
+    def test_stop_job_success(self, manager: JobManager):
+        """Test stop_job successfully stops a process."""
+        # Start a real subprocess
+        proc = subprocess.Popen(
+            ["sleep", "60"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        job = Job.create(
+            command=["sleep", "60"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="stop-test",
+        )
+        job.pid = proc.pid
+        save_job(job, manager.jobs_dir)
+
+        try:
+            success, message = manager.stop_job(job.id, timeout=2)
+
+            assert success
+            assert "stopped" in message.lower()
+
+            # Verify job status updated
+            updated = manager.get_job(job.id, refresh=False)
+            assert updated is not None
+            assert updated.status == JobStatus.STOPPED
+            assert updated.ended_at is not None
+        finally:
+            # Cleanup in case test fails
+            try:
+                proc.terminate()
+                proc.wait(timeout=1)
+            except Exception:
+                proc.kill()
+
+    def test_clean_jobs_empty(self, manager: JobManager):
+        """Test clean_jobs on empty directory."""
+        deleted = manager.clean_jobs()
+        assert deleted == []
+
+    def test_clean_jobs_skips_running(self, manager: JobManager):
+        """Test clean_jobs skips running jobs by default."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="running",
+        )
+        job.pid = os.getpid()  # Valid PID
+        save_job(job, manager.jobs_dir)
+
+        deleted = manager.clean_jobs()
+
+        assert deleted == []
+
+    def test_clean_jobs_deletes_terminal(self, manager: JobManager):
+        """Test clean_jobs deletes terminal jobs."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="done",
+        )
+        job.status = JobStatus.DONE
+        save_job(job, manager.jobs_dir)
+
+        deleted = manager.clean_jobs()
+
+        assert job.id in deleted
+
+    def test_clean_jobs_older_than(self, manager: JobManager):
+        """Test clean_jobs respects older_than_days."""
+        old_job = Job(
+            id="old-1234567",
+            command=["implement"],
+            cwd="/test",
+            log_path=str(manager.jobs_dir / "old.log"),
+            status=JobStatus.DONE,
+            created_at=datetime.now() - timedelta(days=10),
+            started_at=datetime.now() - timedelta(days=10),
+            ended_at=datetime.now() - timedelta(days=10),
+        )
+        new_job = Job(
+            id="new-1234567",
+            command=["implement"],
+            cwd="/test",
+            log_path=str(manager.jobs_dir / "new.log"),
+            status=JobStatus.DONE,
+            created_at=datetime.now(),
+            started_at=datetime.now(),
+            ended_at=datetime.now(),
+        )
+        save_job(old_job, manager.jobs_dir)
+        save_job(new_job, manager.jobs_dir)
+
+        deleted = manager.clean_jobs(older_than_days=7)
+
+        assert "old-1234567" in deleted
+        assert "new-1234567" not in deleted
+
+    def test_update_job(self, manager: JobManager):
+        """Test update_job updates fields."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="update-test",
+        )
+        save_job(job, manager.jobs_dir)
+
+        result = manager.update_job(
+            job.id,
+            status=JobStatus.DONE,
+            exit_code=0,
+        )
+
+        assert result is not None
+        assert result.status == JobStatus.DONE
+        assert result.exit_code == 0
+
+    def test_update_job_not_found(self, manager: JobManager):
+        """Test update_job returns None for missing job."""
+        result = manager.update_job("nonexistent", status=JobStatus.DONE)
+        assert result is None
+
+    def test_running_count(self, manager: JobManager):
+        """Test running_count counts only running jobs."""
+        # Running job with valid PID
+        running_job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="running",
+        )
+        running_job.pid = os.getpid()
+        save_job(running_job, manager.jobs_dir)
+
+        # Done job
+        done_job = Job.create(
+            command=["done"],
+            cwd=Path("/test"),
+            jobs_dir=manager.jobs_dir,
+            job_name="done",
+        )
+        done_job.status = JobStatus.DONE
+        save_job(done_job, manager.jobs_dir)
+
+        count = manager.running_count()
+
+        assert count == 1

--- a/tests/jobs/test_models.py
+++ b/tests/jobs/test_models.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from src.jobs.models import Job, JobStatus, generate_job_id
+from src.jobs.models import Job, JobStatus, generate_job_id, sanitize_job_name
 
 
 class TestJobStatus:
@@ -24,6 +24,53 @@ class TestJobStatus:
         assert JobStatus.DONE.is_terminal()
         assert JobStatus.FAILED.is_terminal()
         assert JobStatus.STOPPED.is_terminal()
+
+
+class TestSanitizeJobName:
+    """Tests for sanitize_job_name function."""
+
+    def test_normal_name(self):
+        """Test normal names pass through."""
+        assert sanitize_job_name("implement") == "implement"
+        assert sanitize_job_name("my-feature") == "my-feature"
+
+    def test_path_traversal(self):
+        """Test path traversal attacks are prevented."""
+        assert sanitize_job_name("../../etc/passwd") == "etc-passwd"
+        assert sanitize_job_name("../secret") == "secret"
+        assert sanitize_job_name("foo/../bar") == "foo-bar"
+
+    def test_forward_slash(self):
+        """Test forward slashes are replaced."""
+        assert sanitize_job_name("path/to/file") == "path-to-file"
+
+    def test_backslash(self):
+        """Test backslashes are replaced."""
+        assert sanitize_job_name("path\\to\\file") == "path-to-file"
+
+    def test_null_byte(self):
+        """Test null bytes are removed."""
+        assert sanitize_job_name("test\x00name") == "testname"
+
+    def test_colon(self):
+        """Test colons are replaced (Windows compatibility)."""
+        assert sanitize_job_name("C:path") == "C-path"
+
+    def test_multiple_dashes_collapsed(self):
+        """Test multiple consecutive dashes are collapsed."""
+        assert sanitize_job_name("foo---bar") == "foo-bar"
+        assert sanitize_job_name("a--b--c") == "a-b-c"
+
+    def test_leading_trailing_dashes_stripped(self):
+        """Test leading/trailing dashes are removed."""
+        assert sanitize_job_name("-foo-") == "foo"
+        assert sanitize_job_name("---bar---") == "bar"
+
+    def test_empty_result_fallback(self):
+        """Test empty result falls back to 'job'."""
+        assert sanitize_job_name("..") == "job"
+        assert sanitize_job_name("///") == "job"
+        assert sanitize_job_name("") == "job"
 
 
 class TestGenerateJobId:

--- a/tests/jobs/test_models.py
+++ b/tests/jobs/test_models.py
@@ -1,0 +1,247 @@
+"""Tests for job models."""
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src.jobs.models import Job, JobStatus, generate_job_id
+
+
+class TestJobStatus:
+    """Tests for JobStatus enum."""
+
+    def test_status_values(self):
+        """Test all status values exist."""
+        assert JobStatus.RUNNING.value == "running"
+        assert JobStatus.DONE.value == "done"
+        assert JobStatus.FAILED.value == "failed"
+        assert JobStatus.STOPPED.value == "stopped"
+
+    def test_is_terminal(self):
+        """Test is_terminal method."""
+        assert not JobStatus.RUNNING.is_terminal()
+        assert JobStatus.DONE.is_terminal()
+        assert JobStatus.FAILED.is_terminal()
+        assert JobStatus.STOPPED.is_terminal()
+
+
+class TestGenerateJobId:
+    """Tests for generate_job_id function."""
+
+    def test_format(self):
+        """Test job ID has correct format."""
+        job_id = generate_job_id("implement")
+        assert job_id.startswith("implement-")
+        assert len(job_id) == len("implement-") + 7  # 7 char hash
+
+    def test_uniqueness(self):
+        """Test job IDs are unique."""
+        ids = {generate_job_id("test") for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_custom_name(self):
+        """Test custom name in job ID."""
+        job_id = generate_job_id("overnight-run")
+        assert job_id.startswith("overnight-run-")
+
+
+class TestJob:
+    """Tests for Job dataclass."""
+
+    def test_create(self, tmp_path: Path):
+        """Test Job.create factory method."""
+        job = Job.create(
+            command=["implement", "--loop"],
+            cwd=Path("/test/repo"),
+            jobs_dir=tmp_path,
+            job_name="my-feature",
+        )
+
+        assert job.id.startswith("my-feature-")
+        assert job.command == ["implement", "--loop"]
+        assert job.cwd == "/test/repo"
+        assert job.log_path == str(tmp_path / f"{job.id}.log")
+        assert job.status == JobStatus.RUNNING
+        assert job.pid is None
+        assert job.created_at is not None
+        assert job.started_at is not None
+        assert job.ended_at is None
+        assert job.exit_code is None
+
+    def test_create_default_name(self, tmp_path: Path):
+        """Test Job.create derives name from command."""
+        job = Job.create(
+            command=["refine", "https://example.com/pr/1"],
+            cwd=Path("/test"),
+            jobs_dir=tmp_path,
+        )
+
+        assert job.id.startswith("refine-")
+
+    def test_to_dict(self):
+        """Test Job.to_dict serialization."""
+        now = datetime.now()
+        job = Job(
+            id="test-abc1234",
+            command=["implement"],
+            cwd="/test",
+            log_path="/logs/test.log",
+            pid=12345,
+            status=JobStatus.RUNNING,
+            created_at=now,
+            started_at=now,
+            ended_at=None,
+            exit_code=None,
+        )
+
+        data = job.to_dict()
+
+        assert data["id"] == "test-abc1234"
+        assert data["command"] == ["implement"]
+        assert data["cwd"] == "/test"
+        assert data["pid"] == 12345
+        assert data["status"] == "running"
+        assert data["created_at"] == now.isoformat()
+        assert data["ended_at"] is None
+        assert data["exit_code"] is None
+
+    def test_from_dict(self):
+        """Test Job.from_dict deserialization."""
+        now = datetime.now()
+        data = {
+            "id": "test-xyz7890",
+            "command": ["refine", "--auto-merge"],
+            "cwd": "/my/repo",
+            "pid": 99999,
+            "status": "done",
+            "log_path": "/logs/test.log",
+            "created_at": now.isoformat(),
+            "started_at": now.isoformat(),
+            "ended_at": (now + timedelta(hours=1)).isoformat(),
+            "exit_code": 0,
+        }
+
+        job = Job.from_dict(data)
+
+        assert job.id == "test-xyz7890"
+        assert job.command == ["refine", "--auto-merge"]
+        assert job.cwd == "/my/repo"
+        assert job.pid == 99999
+        assert job.status == JobStatus.DONE
+        assert job.exit_code == 0
+
+    def test_roundtrip_serialization(self, tmp_path: Path):
+        """Test to_dict/from_dict roundtrip."""
+        original = Job.create(
+            command=["implement", "--loop", "--refine"],
+            cwd=Path("/test/repo"),
+            jobs_dir=tmp_path,
+            job_name="roundtrip-test",
+        )
+        original.pid = 42
+        original.exit_code = 1
+        original.status = JobStatus.FAILED
+
+        data = original.to_dict()
+        restored = Job.from_dict(data)
+
+        assert restored.id == original.id
+        assert restored.command == original.command
+        assert restored.cwd == original.cwd
+        assert restored.pid == original.pid
+        assert restored.status == original.status
+        assert restored.exit_code == original.exit_code
+
+    def test_duration_running(self, tmp_path: Path):
+        """Test duration for running job."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=tmp_path,
+        )
+        # Should have some duration since started_at is set
+        assert job.duration is not None
+        assert job.duration >= 0
+
+    def test_duration_not_started(self):
+        """Test duration for job that hasn't started."""
+        job = Job(
+            id="test-123",
+            command=["implement"],
+            cwd="/test",
+            log_path="/test.log",
+            started_at=None,
+        )
+        assert job.duration is None
+
+    def test_duration_completed(self):
+        """Test duration for completed job."""
+        now = datetime.now()
+        job = Job(
+            id="test-456",
+            command=["implement"],
+            cwd="/test",
+            log_path="/test.log",
+            started_at=now,
+            ended_at=now + timedelta(hours=2, minutes=30),
+        )
+        # 2.5 hours = 9000 seconds
+        assert job.duration == pytest.approx(9000, rel=1)
+
+    def test_format_duration_seconds(self):
+        """Test format_duration for short durations."""
+        job = Job(
+            id="test-1",
+            command=[],
+            cwd="/",
+            log_path="/test.log",
+            started_at=datetime.now(),
+            ended_at=datetime.now() + timedelta(seconds=45),
+        )
+        assert job.format_duration() == "45s"
+
+    def test_format_duration_minutes(self):
+        """Test format_duration for minute durations."""
+        job = Job(
+            id="test-2",
+            command=[],
+            cwd="/",
+            log_path="/test.log",
+            started_at=datetime.now(),
+            ended_at=datetime.now() + timedelta(minutes=12, seconds=30),
+        )
+        assert job.format_duration() == "12m 30s"
+
+    def test_format_duration_hours(self):
+        """Test format_duration for hour durations."""
+        job = Job(
+            id="test-3",
+            command=[],
+            cwd="/",
+            log_path="/test.log",
+            started_at=datetime.now(),
+            ended_at=datetime.now() + timedelta(hours=2, minutes=15),
+        )
+        assert job.format_duration() == "2h 15m"
+
+    def test_format_duration_not_started(self):
+        """Test format_duration for job that hasn't started."""
+        job = Job(
+            id="test-4",
+            command=[],
+            cwd="/",
+            log_path="/test.log",
+            started_at=None,
+        )
+        assert job.format_duration() == "-"
+
+    def test_metadata_path(self, tmp_path: Path):
+        """Test metadata_path method."""
+        job = Job(
+            id="test-meta123",
+            command=[],
+            cwd="/",
+            log_path="/test.log",
+        )
+        assert job.metadata_path(tmp_path) == tmp_path / "test-meta123.json"

--- a/tests/jobs/test_storage.py
+++ b/tests/jobs/test_storage.py
@@ -1,0 +1,291 @@
+"""Tests for job storage operations."""
+
+from datetime import datetime
+from pathlib import Path
+
+from src.jobs.models import Job, JobStatus
+from src.jobs.storage import (
+    delete_job,
+    ensure_jobs_dir,
+    find_job_by_prefix,
+    get_log_path,
+    list_jobs,
+    load_job,
+    save_job,
+)
+
+
+class TestEnsureJobsDir:
+    """Tests for ensure_jobs_dir function."""
+
+    def test_creates_directory(self, tmp_path: Path):
+        """Test directory is created if it doesn't exist."""
+        jobs_dir = tmp_path / "jobs"
+        assert not jobs_dir.exists()
+
+        result = ensure_jobs_dir(jobs_dir)
+
+        assert jobs_dir.exists()
+        assert result == jobs_dir
+
+    def test_existing_directory(self, tmp_path: Path):
+        """Test works with existing directory."""
+        jobs_dir = tmp_path / "jobs"
+        jobs_dir.mkdir()
+
+        result = ensure_jobs_dir(jobs_dir)
+
+        assert result == jobs_dir
+
+    def test_nested_directory(self, tmp_path: Path):
+        """Test creates nested directories."""
+        jobs_dir = tmp_path / "deeply" / "nested" / "jobs"
+
+        result = ensure_jobs_dir(jobs_dir)
+
+        assert jobs_dir.exists()
+        assert result == jobs_dir
+
+
+class TestSaveAndLoadJob:
+    """Tests for save_job and load_job functions."""
+
+    def test_save_job_creates_file(self, tmp_path: Path):
+        """Test save_job creates JSON file."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=tmp_path,
+            job_name="test",
+        )
+
+        save_job(job, tmp_path)
+
+        metadata_path = tmp_path / f"{job.id}.json"
+        assert metadata_path.exists()
+
+    def test_load_job_returns_job(self, tmp_path: Path):
+        """Test load_job returns saved job."""
+        original = Job.create(
+            command=["implement", "--loop"],
+            cwd=Path("/my/repo"),
+            jobs_dir=tmp_path,
+            job_name="load-test",
+        )
+        original.pid = 12345
+        save_job(original, tmp_path)
+
+        loaded = load_job(original.id, tmp_path)
+
+        assert loaded is not None
+        assert loaded.id == original.id
+        assert loaded.command == original.command
+        assert loaded.cwd == original.cwd
+        assert loaded.pid == original.pid
+
+    def test_load_job_not_found(self, tmp_path: Path):
+        """Test load_job returns None for missing job."""
+        result = load_job("nonexistent-1234567", tmp_path)
+        assert result is None
+
+    def test_save_updates_existing(self, tmp_path: Path):
+        """Test save_job updates existing job file."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=tmp_path,
+            job_name="update-test",
+        )
+        save_job(job, tmp_path)
+
+        # Update and save again
+        job.status = JobStatus.DONE
+        job.exit_code = 0
+        save_job(job, tmp_path)
+
+        loaded = load_job(job.id, tmp_path)
+        assert loaded is not None
+        assert loaded.status == JobStatus.DONE
+        assert loaded.exit_code == 0
+
+
+class TestListJobs:
+    """Tests for list_jobs function."""
+
+    def test_empty_directory(self, tmp_path: Path):
+        """Test list_jobs returns empty list for empty directory."""
+        jobs = list_jobs(tmp_path)
+        assert jobs == []
+
+    def test_lists_all_jobs(self, tmp_path: Path):
+        """Test list_jobs returns all jobs."""
+        job1 = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=tmp_path,
+            job_name="job1",
+        )
+        job2 = Job.create(
+            command=["refine"],
+            cwd=Path("/test"),
+            jobs_dir=tmp_path,
+            job_name="job2",
+        )
+        save_job(job1, tmp_path)
+        save_job(job2, tmp_path)
+
+        jobs = list_jobs(tmp_path)
+
+        assert len(jobs) == 2
+        job_ids = {j.id for j in jobs}
+        assert job1.id in job_ids
+        assert job2.id in job_ids
+
+    def test_sorted_by_created_at(self, tmp_path: Path):
+        """Test list_jobs returns newest first."""
+        from datetime import timedelta
+
+        now = datetime.now()
+
+        job_old = Job(
+            id="old-1234567",
+            command=["old"],
+            cwd="/test",
+            log_path=str(tmp_path / "old.log"),
+            created_at=now - timedelta(days=1),
+            started_at=now - timedelta(days=1),
+        )
+        job_new = Job(
+            id="new-1234567",
+            command=["new"],
+            cwd="/test",
+            log_path=str(tmp_path / "new.log"),
+            created_at=now,
+            started_at=now,
+        )
+
+        save_job(job_old, tmp_path)
+        save_job(job_new, tmp_path)
+
+        jobs = list_jobs(tmp_path)
+
+        assert jobs[0].id == "new-1234567"
+        assert jobs[1].id == "old-1234567"
+
+
+class TestDeleteJob:
+    """Tests for delete_job function."""
+
+    def test_deletes_metadata(self, tmp_path: Path):
+        """Test delete_job removes metadata file."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=tmp_path,
+            job_name="delete-test",
+        )
+        save_job(job, tmp_path)
+        assert (tmp_path / f"{job.id}.json").exists()
+
+        result = delete_job(job.id, tmp_path)
+
+        assert result is True
+        assert not (tmp_path / f"{job.id}.json").exists()
+
+    def test_deletes_log_file(self, tmp_path: Path):
+        """Test delete_job removes log file if present."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=tmp_path,
+            job_name="delete-log-test",
+        )
+        save_job(job, tmp_path)
+
+        # Create log file
+        log_path = tmp_path / f"{job.id}.log"
+        log_path.write_text("some logs")
+
+        result = delete_job(job.id, tmp_path)
+
+        assert result is True
+        assert not log_path.exists()
+
+    def test_returns_false_for_missing(self, tmp_path: Path):
+        """Test delete_job returns False for nonexistent job."""
+        result = delete_job("nonexistent-1234567", tmp_path)
+        assert result is False
+
+
+class TestFindJobByPrefix:
+    """Tests for find_job_by_prefix function."""
+
+    def test_finds_exact_match(self, tmp_path: Path):
+        """Test finds job by exact ID."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=tmp_path,
+            job_name="prefix-test",
+        )
+        save_job(job, tmp_path)
+
+        found = find_job_by_prefix(job.id, tmp_path)
+
+        assert found is not None
+        assert found.id == job.id
+
+    def test_finds_by_prefix(self, tmp_path: Path):
+        """Test finds job by ID prefix."""
+        job = Job.create(
+            command=["implement"],
+            cwd=Path("/test"),
+            jobs_dir=tmp_path,
+            job_name="findme",
+        )
+        save_job(job, tmp_path)
+
+        # Use just the name part as prefix
+        found = find_job_by_prefix("findme-", tmp_path)
+
+        assert found is not None
+        assert found.id == job.id
+
+    def test_returns_none_for_multiple_matches(self, tmp_path: Path):
+        """Test returns None if multiple jobs match prefix."""
+        for _ in range(3):
+            job = Job.create(
+                command=["implement"],
+                cwd=Path("/test"),
+                jobs_dir=tmp_path,
+                job_name="multi",
+            )
+            save_job(job, tmp_path)
+
+        found = find_job_by_prefix("multi-", tmp_path)
+
+        # Should return None because multiple match
+        assert found is None
+
+    def test_returns_none_for_no_match(self, tmp_path: Path):
+        """Test returns None for no matches."""
+        found = find_job_by_prefix("nonexistent-", tmp_path)
+        assert found is None
+
+
+class TestGetLogPath:
+    """Tests for get_log_path function."""
+
+    def test_returns_correct_path(self, tmp_path: Path):
+        """Test returns correct log path."""
+        result = get_log_path("test-abc1234", tmp_path)
+        assert result == tmp_path / "test-abc1234.log"
+
+    def test_creates_directory(self, tmp_path: Path):
+        """Test creates jobs directory."""
+        jobs_dir = tmp_path / "jobs"
+        assert not jobs_dir.exists()
+
+        get_log_path("test-xyz", jobs_dir)
+
+        assert jobs_dir.exists()

--- a/tests/jobs/test_wrapper.py
+++ b/tests/jobs/test_wrapper.py
@@ -1,0 +1,157 @@
+"""Tests for job wrapper module."""
+
+import json
+import sys
+from pathlib import Path
+
+from src.jobs.wrapper import main, run_job, update_job_metadata
+
+
+class TestUpdateJobMetadata:
+    """Tests for update_job_metadata function."""
+
+    def test_updates_status_on_success(self, tmp_path: Path):
+        """Test metadata is updated with done status on exit code 0."""
+        job_id = "test-123"
+        metadata_path = tmp_path / f"{job_id}.json"
+
+        # Create initial metadata
+        initial_data = {
+            "id": job_id,
+            "status": "running",
+            "command": ["echo", "hello"],
+        }
+        metadata_path.write_text(json.dumps(initial_data))
+
+        update_job_metadata(job_id, tmp_path, exit_code=0)
+
+        updated = json.loads(metadata_path.read_text())
+        assert updated["status"] == "done"
+        assert updated["exit_code"] == 0
+        assert "ended_at" in updated
+
+    def test_updates_status_on_failure(self, tmp_path: Path):
+        """Test metadata is updated with failed status on non-zero exit."""
+        job_id = "test-456"
+        metadata_path = tmp_path / f"{job_id}.json"
+
+        initial_data = {"id": job_id, "status": "running"}
+        metadata_path.write_text(json.dumps(initial_data))
+
+        update_job_metadata(job_id, tmp_path, exit_code=1)
+
+        updated = json.loads(metadata_path.read_text())
+        assert updated["status"] == "failed"
+        assert updated["exit_code"] == 1
+
+    def test_handles_missing_metadata(self, tmp_path: Path, capsys):
+        """Test gracefully handles missing metadata file."""
+        update_job_metadata("nonexistent", tmp_path, exit_code=0)
+
+        captured = capsys.readouterr()
+        assert "Warning: Job metadata not found" in captured.err
+
+
+class TestRunJob:
+    """Tests for run_job function."""
+
+    def test_runs_command_and_updates_metadata(self, tmp_path: Path):
+        """Test runs command and updates metadata."""
+        job_id = "test-run"
+        metadata_path = tmp_path / f"{job_id}.json"
+
+        initial_data = {"id": job_id, "status": "running"}
+        metadata_path.write_text(json.dumps(initial_data))
+
+        exit_code = run_job(job_id, tmp_path, ["echo", "hello"])
+
+        assert exit_code == 0
+        updated = json.loads(metadata_path.read_text())
+        assert updated["status"] == "done"
+
+    def test_captures_failure_exit_code(self, tmp_path: Path):
+        """Test captures non-zero exit code."""
+        job_id = "test-fail"
+        metadata_path = tmp_path / f"{job_id}.json"
+
+        initial_data = {"id": job_id, "status": "running"}
+        metadata_path.write_text(json.dumps(initial_data))
+
+        exit_code = run_job(job_id, tmp_path, ["false"])  # 'false' always exits 1
+
+        assert exit_code == 1
+        updated = json.loads(metadata_path.read_text())
+        assert updated["status"] == "failed"
+
+    def test_handles_command_not_found(self, tmp_path: Path):
+        """Test handles command not found gracefully."""
+        job_id = "test-notfound"
+        metadata_path = tmp_path / f"{job_id}.json"
+
+        initial_data = {"id": job_id, "status": "running"}
+        metadata_path.write_text(json.dumps(initial_data))
+
+        exit_code = run_job(job_id, tmp_path, ["nonexistent_command_xyz"])
+
+        assert exit_code != 0
+        updated = json.loads(metadata_path.read_text())
+        assert updated["status"] == "failed"
+
+
+class TestMain:
+    """Tests for main entry point."""
+
+    def test_missing_args(self):
+        """Test exits with error on missing arguments."""
+        exit_code = main([])
+        assert exit_code == 1
+
+    def test_missing_separator(self):
+        """Test exits with error on missing -- separator."""
+        exit_code = main(["job-id", "/tmp/jobs", "echo", "hello"])
+        assert exit_code == 1
+
+    def test_missing_command(self):
+        """Test exits with error on missing command after --."""
+        exit_code = main(["job-id", "/tmp/jobs", "--"])
+        assert exit_code == 1
+
+    def test_runs_command(self, tmp_path: Path):
+        """Test runs command via main entry point."""
+        job_id = "test-main"
+        metadata_path = tmp_path / f"{job_id}.json"
+
+        initial_data = {"id": job_id, "status": "running"}
+        metadata_path.write_text(json.dumps(initial_data))
+
+        exit_code = main([job_id, str(tmp_path), "--", "echo", "hello"])
+
+        assert exit_code == 0
+        updated = json.loads(metadata_path.read_text())
+        assert updated["status"] == "done"
+
+    def test_passes_command_args(self, tmp_path: Path):
+        """Test command arguments are passed correctly."""
+        job_id = "test-args"
+        metadata_path = tmp_path / f"{job_id}.json"
+        output_file = tmp_path / "output.txt"
+
+        initial_data = {"id": job_id, "status": "running"}
+        metadata_path.write_text(json.dumps(initial_data))
+
+        # Use a command that writes args to a file
+        exit_code = main(
+            [
+                job_id,
+                str(tmp_path),
+                "--",
+                sys.executable,
+                "-c",
+                f"import sys; open('{output_file}', 'w').write(' '.join(sys.argv[1:]))",
+                "arg1",
+                "arg2",
+            ]
+        )
+
+        assert exit_code == 0
+        assert output_file.read_text() == "arg1 arg2"

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,30 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/13/3b893421369767e7043cc115d6ef0df417c298b84563be3a12df0416158d/agent_client_protocol-0.9.0.tar.gz", hash = "sha256:f744c48ab9af0f0b4452e5ab5498d61bcab97c26dbe7d6feec5fd36de49be30b", size = 71853, upload-time = "2026-03-26T01:21:00.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/ed/c284543c08aa443a4ef2c8bd120be51da8433dd174c01749b5d87c333f22/agent_client_protocol-0.9.0-py3-none-any.whl", hash = "sha256:06911500b51d8cb69112544e2be01fc5e7db39ef88fecbc3848c5c6f194798ee", size = 56850, upload-time = "2026-03-26T01:20:59.252Z" },
+]
+
+[[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -330,6 +354,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bc/1d/ede8680603f6016887c062a2cf4fc8fdba905866a3ab8831aa8aa651320c/cachetools-6.2.4.tar.gz", hash = "sha256:82c5c05585e70b6ba2d3ae09ea60b79548872185d2f24ae1f2709d37299fd607", size = 31731, upload-time = "2025-12-15T18:24:53.744Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/fc/1d7b80d0eb7b714984ce40efc78859c022cd930e402f599d8ca9e39c78a4/cachetools-6.2.4-py3-none-any.whl", hash = "sha256:69a7a52634fed8b8bf6e24a050fb60bff1c9bd8f6d24572b99c32d4e71e62a51", size = 11551, upload-time = "2025-12-15T18:24:52.332Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -691,15 +736,6 @@ wheels = [
 ]
 
 [[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
-]
-
-[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -780,29 +816,34 @@ lua = [
 
 [[package]]
 name = "fastmcp"
-version = "2.14.2"
+version = "3.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "httpx" },
+    { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
     { name = "platformdirs" },
-    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "pydantic", extra = ["email"] },
-    { name = "pydocket" },
     { name = "pyperclip" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "rich" },
+    { name = "uncalled-for" },
     { name = "uvicorn" },
+    { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/1e/e3528227688c248283f6d86869b1e900563ffc223eff00f4f923d2750365/fastmcp-2.14.2.tar.gz", hash = "sha256:bd23d1b808b6f446444f10114dac468b11bfb9153ed78628f5619763d0cf573e", size = 8272966, upload-time = "2025-12-31T15:26:13.433Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/42/7eed0a38e3b7a386805fecacf8a5a9353a2b3040395ef9e30e585d8549ac/fastmcp-3.2.3.tar.gz", hash = "sha256:4f02ae8b00227285a0cf6544dea1db29b022c8cdd8d3dfdec7118540210ae60a", size = 26328743, upload-time = "2026-04-09T22:05:03.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/67/8456d39484fcb7afd0defed21918e773ed59a98b39e5b633328527c88367/fastmcp-2.14.2-py3-none-any.whl", hash = "sha256:e33cd622e1ebd5110af6a981804525b6cd41072e3c7d68268ed69ef3be651aca", size = 413279, upload-time = "2025-12-31T15:26:11.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/48/84b6dcba793178a44b9d99b4def6cd62f870dcfc5bb7b9153ac390135812/fastmcp-3.2.3-py3-none-any.whl", hash = "sha256:cc50af6eed1f62ed8b6ebf4987286d8d1d006f08d5bec739d5c7fb76160e0911", size = 707260, upload-time = "2026-04-09T22:05:01.225Z" },
 ]
 
 [[package]]
@@ -1238,6 +1279,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -1443,6 +1489,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1512,7 +1567,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.80.11"
+version = "1.80.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1530,9 +1585,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/47/be6cd7b356418ca8bef3b843507940ce77b76ef2dfe515f2b4ba9b461ff0/litellm-1.80.11.tar.gz", hash = "sha256:c9fc63e7acb6360363238fe291bcff1488c59ff66020416d8376c0ee56414a19", size = 13189510, upload-time = "2025-12-22T12:47:29.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/44/0aaa7449e7c4aa05668ec03f1f68a01b1e476591071d9659a68db19371a2/litellm-1.80.10.tar.gz", hash = "sha256:4a4aff7558945c2f7e5c6523e67c1b5525a46b10b0e1ad6b8f847cb13b16779e", size = 12764777, upload-time = "2025-12-14T02:07:05.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/0b/9e637344f24f3fe0e8039cd2337389fe05e0d31f518bc3e0a5cdbe45784a/litellm-1.80.11-py3-none-any.whl", hash = "sha256:406283d66ead77dc7ff0e0b2559c80e9e497d8e7c2257efb1cb9210a20d09d54", size = 11456346, upload-time = "2025-12-22T12:47:26.469Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a9/4814b6aa58f6705df2831eaadeb5bc8240684c8c9d5964245212f85049d1/litellm-1.80.10-py3-none-any.whl", hash = "sha256:9b3e561efaba0eb1291cb1555d3dcb7283cf7f3cb65aadbcdb42e2a8765898c8", size = 11264240, upload-time = "2025-12-14T02:07:02.414Z" },
 ]
 
 [[package]]
@@ -1647,8 +1702,8 @@ requires-dist = [
     { name = "charset-normalizer", specifier = ">=2.0.0,<4.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mdformat", specifier = ">=0.7" },
-    { name = "openhands-sdk", specifier = ">=0.9.0" },
-    { name = "openhands-tools", specifier = ">=1.7.0" },
+    { name = "openhands-sdk", specifier = "==1.16.1" },
+    { name = "openhands-tools", specifier = "==1.16.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pymarkdownlnt", specifier = ">=0.9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -2053,12 +2108,15 @@ wheels = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.7.3"
+version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "agent-client-protocol" },
     { name = "deprecation" },
+    { name = "fakeredis", extra = ["lua"] },
     { name = "fastmcp" },
-    { name = "httpx" },
+    { name = "filelock" },
+    { name = "httpx", extra = ["socks"] },
     { name = "litellm" },
     { name = "lmnr" },
     { name = "pydantic" },
@@ -2067,14 +2125,14 @@ dependencies = [
     { name = "tenacity" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/19/d4ab1d9b6e7a1ce017c4b53d50db01cb62a2f2b3dea26688db3ce6ee08e7/openhands_sdk-1.7.3.tar.gz", hash = "sha256:7fa0cde9148ab905e24346b50f2d7267fb6dde32ec8dcbc1c7d35ced6e0233aa", size = 210785, upload-time = "2025-12-30T17:49:18.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/b1/d1fd2a29e0c60e0277fb0191e8272873c7ff4e31f317f1edff1e02430309/openhands_sdk-1.16.1.tar.gz", hash = "sha256:12f203c3766800bdf5d9dd4dd0a7988b88e13ff4954b0c208903778111e29567", size = 352455, upload-time = "2026-04-02T15:21:52.378Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/ba/e57f50ffb7a7b9fe1cf150fb363439b75ba06749ff3ebd56c6d77681eb02/openhands_sdk-1.7.3-py3-none-any.whl", hash = "sha256:afbce9c9e7d1167d9b9610673657fbbcd454b04f0151d943418d897de790aeed", size = 276547, upload-time = "2025-12-30T17:49:16.004Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f9/c002ec8e9b8bf3b4967afc433409cdef62e356274f4ea4fdda87fe9ef805/openhands_sdk-1.16.1-py3-none-any.whl", hash = "sha256:0b487929e03e8c87ac6d99f37ff5314df3db6af70a06b516b0858327f9744f2b", size = 445227, upload-time = "2026-04-02T15:21:51.074Z" },
 ]
 
 [[package]]
 name = "openhands-tools"
-version = "1.7.3"
+version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bashlex" },
@@ -2087,9 +2145,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "tom-swe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c0/002c24ff28dce6b9826e7e1fffcb37340b450dd9496b0d354df36cc40ad0/openhands_tools-1.7.3.tar.gz", hash = "sha256:f2779cc5ca3b78b9afebb7617006da8069c12b41e6d67cbf0cc8de5d819005f8", size = 91548, upload-time = "2025-12-30T17:49:13.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/63/8532589b14744196cf12c1d337b34b6c85f5b1e26eefc6b457570573fd28/openhands_tools-1.16.1.tar.gz", hash = "sha256:64488f2d7705ff90f4bfb7dfd1a2f1fbb4f379059d96e0073677c168d97135e7", size = 117133, upload-time = "2026-04-02T15:21:47.806Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/4d/c0d67f9ea5fa4a0fdf38fa2cf4afd7ba906f39c776c6df4c931bf0f8a663/openhands_tools-1.7.3-py3-none-any.whl", hash = "sha256:e823f5a47936dd23221cb4eb846d62b59dce5be69210330095fc242772e71d27", size = 127478, upload-time = "2025-12-30T17:49:19.836Z" },
+    { url = "https://files.pythonhosted.org/packages/af/41/d78c1927eba7bfc0492a6d80c97c03d4f1e1aa6798ff5d47c21f4fda5048/openhands_tools-1.16.1-py3-none-any.whl", hash = "sha256:f7fd1eb205571d02ee480ad71e96cac0c34c57c0938c4074fe135a579a7538d7", size = 158190, upload-time = "2026-04-02T15:21:53.969Z" },
 ]
 
 [[package]]
@@ -2152,20 +2210,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-prometheus"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "prometheus-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/14/39/7dafa6fff210737267bed35a8855b6ac7399b9e582b8cf1f25f842517012/opentelemetry_exporter_prometheus-0.60b1.tar.gz", hash = "sha256:a4011b46906323f71724649d301b4dc188aaa068852e814f4df38cc76eac616b", size = 14976, upload-time = "2025-12-11T13:32:42.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/0d/4be6bf5477a3eb3d917d2f17d3c0b6720cd6cb97898444a61d43cc983f5c/opentelemetry_exporter_prometheus-0.60b1-py3-none-any.whl", hash = "sha256:49f59178de4f4590e3cef0b8b95cf6e071aae70e1f060566df5546fad773b8fd", size = 13019, upload-time = "2025-12-11T13:32:23.974Z" },
 ]
 
 [[package]]
@@ -2317,15 +2361,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathvalidate"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
-]
-
-[[package]]
 name = "pfzy"
 version = "0.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2448,15 +2483,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/a9/90bee782b3122b69462c579c496e2431786d3d1adebd1bff66d5e69f66cf/posthog-7.4.2.tar.gz", hash = "sha256:5953f31a21c5e2485ac57eb5d600a231a70118f884f438c0e8b493c30373c409", size = 144136, upload-time = "2025-12-22T11:03:15.301Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/95/ed48309ec45d8856e38c07ff2f65e7f904e2e4249905d2bf903e2eb0ad32/posthog-7.4.2-py3-none-any.whl", hash = "sha256:36954f06f4adede905d97faeb24926a705a4d86f4a308506b15b41b661ef064c", size = 166516, upload-time = "2025-12-22T11:03:14.27Z" },
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.23.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/53/3edb5d68ecf6b38fcbcc1ad28391117d2a322d9a1a3eff04bfdb184d8c3b/prometheus_client-0.23.1.tar.gz", hash = "sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce", size = 80481, upload-time = "2025-09-18T20:47:25.043Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/db/14bafcb4af2139e046d03fd00dea7873e48eafe18b7d2797e73d6681f210/prometheus_client-0.23.1-py3-none-any.whl", hash = "sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99", size = 61145, upload-time = "2025-09-18T20:47:23.875Z" },
 ]
 
 [[package]]
@@ -2612,43 +2638,27 @@ wheels = [
 
 [[package]]
 name = "py-key-value-aio"
-version = "0.3.0"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
-    { name = "py-key-value-shared" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
 ]
 
 [package.optional-dependencies]
-disk = [
-    { name = "diskcache" },
-    { name = "pathvalidate" },
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
 ]
 keyring = [
     { name = "keyring" },
 ]
 memory = [
     { name = "cachetools" },
-]
-redis = [
-    { name = "redis" },
-]
-
-[[package]]
-name = "py-key-value-shared"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
 ]
 
 [[package]]
@@ -2796,29 +2806,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
-]
-
-[[package]]
-name = "pydocket"
-version = "0.16.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cloudpickle" },
-    { name = "fakeredis", extra = ["lua"] },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-prometheus" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "prometheus-client" },
-    { name = "py-key-value-aio", extra = ["memory", "redis"] },
-    { name = "python-json-logger" },
-    { name = "redis" },
-    { name = "rich" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/c5/61dcfce4d50b66a3f09743294d37fab598b81bb0975054b7f732da9243ec/pydocket-0.16.3.tar.gz", hash = "sha256:78e9da576de09e9f3f410d2471ef1c679b7741ddd21b586c97a13872b69bd265", size = 297080, upload-time = "2025-12-23T23:37:33.32Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/94/93b7f5981aa04f922e0d9ce7326a4587866ec7e39f7c180ffcf408e66ee8/pydocket-0.16.3-py3-none-any.whl", hash = "sha256:e2b50925356e7cd535286255195458ac7bba15f25293356651b36d223db5dd7c", size = 67087, upload-time = "2025-12-23T23:37:31.829Z" },
 ]
 
 [[package]]
@@ -6190,6 +6177,15 @@ wheels = [
 ]
 
 [[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6408,21 +6404,6 @@ wheels = [
 ]
 
 [[package]]
-name = "typer"
-version = "0.21.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/85/30/ff9ede605e3bd086b4dd842499814e128500621f7951ca1e5ce84bbf61b1/typer-0.21.0.tar.gz", hash = "sha256:c87c0d2b6eee3b49c5c64649ec92425492c14488096dfbc8a0c2799b2f6f9c53", size = 106781, upload-time = "2025-12-25T09:54:53.651Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e4/5ebc1899d31d2b1601b32d21cfb4bba022ae6fce323d365f0448031b1660/typer-0.21.0-py3-none-any.whl", hash = "sha256:c79c01ca6b30af9fd48284058a7056ba0d3bf5cf10d0ff3d0c5b11b68c258ac6", size = 47109, upload-time = "2025-12-25T09:54:51.918Z" },
-]
-
-[[package]]
 name = "typer-slim"
 version = "0.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6454,6 +6435,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/68/35c1d87e608940badbcfeb630347aa0509897284684f61fab6423d02b253/uncalled_for-0.3.1.tar.gz", hash = "sha256:5e412ac6708f04b56bef5867b5dcf6690ebce4eb7316058d9c50787492bb4bca", size = 49693, upload-time = "2026-04-07T13:05:06.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/e1/7ec67882ad8fc9f86384bef6421fa252c9cbe5744f8df6ce77afc9eca1f5/uncalled_for-0.3.1-py3-none-any.whl", hash = "sha256:074cdc92da8356278f93d0ded6f2a66dd883dbecaf9bc89437646ee2289cc200", size = 11361, upload-time = "2026-04-07T13:05:05.341Z" },
 ]
 
 [[package]]
@@ -6494,6 +6484,76 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements GitHub issue #68: Background job management for long-running commands.

## Features

- **Background execution**: Run commands with `--background` flag on `implement` and `refine`
- **Custom job names**: Use `--job-name` to set a custom name for the job
- **Detached processes**: Jobs survive terminal exit (uses `setsid`/`start_new_session`)
- **Job metadata**: Stored in `~/.lxa/jobs/` with automatic status updates on completion

## Job Control Commands

```bash
lxa job list                    # List all jobs with status
lxa job status <id>             # Show detailed job info
lxa job logs <id>               # View job output
lxa job logs <id> --follow      # Tail logs in real-time
lxa job stop <id>               # Gracefully stop running jobs
lxa job clean --older-than 7    # Clean up old job files
```

## Usage Examples

```bash
# Start implementation in background
lxa implement --loop --background
# Output: Started job implement-a3f2b1c, logs at ~/.lxa/jobs/implement-a3f2b1c.log

# With custom name
lxa implement --loop --background --job-name overnight-run

# Refine a PR in background
lxa refine https://github.com/owner/repo/pull/42 --background --job-name pr42-refine
```

## Implementation

### New Package: `src/jobs/`

| Module | Description |
|--------|-------------|
| `models.py` | `Job` dataclass and `JobStatus` enum |
| `storage.py` | JSON file persistence in `~/.lxa/jobs/` |
| `manager.py` | `JobManager` class for CRUD operations |
| `executor.py` | `spawn_detached()` for background process spawning |
| `cli/` | CLI presentation layer for job commands |

## Tests

75 new tests covering all functionality:
- `test_models.py`: 18 tests for Job and JobStatus
- `test_storage.py`: 19 tests for storage operations  
- `test_manager.py`: 25 tests for JobManager
- `test_executor.py`: 13 tests for detached execution

## Checklist

- [x] `--background` flag starts detached process that survives terminal exit
- [x] `--job-name` allows custom naming with auto-appended hash
- [x] `lxa job list` shows running and recent jobs
- [x] `lxa job status <id>` shows detailed job info
- [x] `lxa job logs <id>` displays log contents
- [x] `lxa job logs <id> --follow` tails logs in real-time
- [x] `lxa job stop <id>` gracefully terminates running jobs
- [x] Jobs directory created at `~/.lxa/jobs/`
- [x] Metadata persists across restarts

Closes #68

---
*This PR was created by an AI assistant (OpenHands) on behalf of jpshackelford.*