### PR TITLE
docs: Update README and board-management for today's features

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ lxa implement
 
 # Start from a specific design document
 lxa implement doc/design/feature-name.md
+
+# Run in background (detached from terminal)
+lxa implement --background
+
+# Custom job name for background execution
+lxa implement --background --job-name my-feature
 ```
 
 ### Ralph Loop Mode (Continuous Execution)
@@ -91,6 +97,9 @@ lxa refine https://github.com/owner/repo/pull/42 --phase respond
 
 # Configure quality bar and iteration limits
 lxa refine URL --allow-merge good_taste --max-iterations 10
+
+# Run in background (detached from terminal)
+lxa refine URL --background --job-name pr-review
 ```
 
 The refinement loop has two phases:
@@ -138,6 +147,26 @@ The task runner provides a simple agent with:
 - Task tracking for structured work
 
 Background jobs can be managed with the `lxa job` command (see below).
+
+### Output Verbosity
+
+Control agent output detail with the `--verbosity` flag (available on `implement`, `refine`, and `run`):
+
+```bash
+# Quiet mode: show only action summaries (default for background jobs)
+lxa implement --verbosity quiet
+
+# Normal mode: show reasoning + summaries (default for foreground)
+lxa implement --verbosity normal
+
+# Verbose mode: show all details including file contents
+lxa implement --verbosity verbose
+# or shorthand
+lxa implement -v verbose
+
+# Include timestamps in output (useful for debugging)
+lxa implement --timestamps
+```
 
 ### Reconciliation (Post-merge)
 
@@ -221,8 +250,11 @@ lxa board rm "Old Board"
 Track AI-assisted development across multiple repositories with GitHub Projects:
 
 ```bash
-# Create a new board
+# Create a new board (user-scoped, tracks your activity)
 lxa board init --create "My Agent Board"
+
+# Create a project-scoped board (tracks specific items for a project)
+lxa board init --create "Feature X" --scope project --overview https://github.com/owner/repo/issues/1
 
 # Option A: Add specific repos to watch
 lxa board config repos add owner/repo1
@@ -233,12 +265,23 @@ lxa board scan
 lxa board scan --user myusername --since 21    # All your personal repos
 lxa board scan --org my-company --since 14     # All repos in an org
 
+# Manually add items to a board
+lxa board add-item https://github.com/owner/repo/pull/123
+lxa board add-item owner/repo#456 repo#789 --column "Backlog"
+
+# Sync config to/from GitHub Gist (for ephemeral environments)
+lxa board sync-config
+
 # Incremental sync using notifications
 lxa board sync
 
 # Check what needs attention
 lxa board status --attention
 ```
+
+**Board Scopes:**
+- **User-scoped** (default): Automatically tracks all issues/PRs where you're involved
+- **Project-scoped**: Tracks a fixed set of items for a specific project; requires an `--overview` item as the anchor
 
 The board automatically organizes items into workflow columns based on their state:
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ lxa implement --verbosity normal
 
 # Verbose mode: show all details including file contents
 lxa implement --verbosity verbose
-# or shorthand
+# or shorthand (note: -v requires a value)
 lxa implement -v verbose
 
 # Include timestamps in output (useful for debugging)

--- a/doc/reference/board-management.md
+++ b/doc/reference/board-management.md
@@ -35,8 +35,11 @@ lxa board status --attention
 Initialize or configure a GitHub Project board.
 
 ```bash
-# Create a new project
+# Create a new project (user-scoped by default)
 lxa board init --create "Project Name"
+
+# Create a project-scoped board (tracks fixed set of items for a project)
+lxa board init --create "Feature X" --scope project --overview https://github.com/owner/repo/issues/1
 
 # Configure an existing project by number
 lxa board init --project-number 5
@@ -47,6 +50,21 @@ lxa board init --project-id PVT_kwHOABcd12
 # Preview without making changes
 lxa board init --create "Test Board" --dry-run
 ```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--create NAME` | Create a new project with this name |
+| `--project-number N` | Configure existing user project by number |
+| `--project-id ID` | Configure existing project by GraphQL ID |
+| `--board NAME` | Name for this board in config (default: slugified project name) |
+| `--scope SCOPE` | Board scope: `user` (default) or `project` |
+| `--overview URL` | URL of overview item (required for project-scoped boards) |
+| `--dry-run` | Show what would be done without making changes |
+
+**Board Scopes:**
+- **User-scoped** (default): Automatically tracks all issues/PRs where you're involved across watched repos. The `scan` command finds items based on your activity.
+- **Project-scoped**: Tracks a fixed set of items related to a specific project/initiative. Items must be added manually with `lxa board add-item`. The `--overview` option specifies an anchor issue/PR that describes the project.
 
 This command:
 - Creates a new GitHub Project (or connects to an existing one)
@@ -187,6 +205,34 @@ lxa board apply --dry-run
 # Remove columns not in config
 lxa board apply --prune
 ```
+
+### `lxa board add-item`
+
+Manually add issues or PRs to a board.
+
+```bash
+# Add by URL
+lxa board add-item https://github.com/owner/repo/pull/123
+
+# Add by reference (multiple formats supported)
+lxa board add-item owner/repo#123
+lxa board add-item repo#456              # When repo is unique in board config
+lxa board add-item #789                  # When board has exactly one repo
+
+# Add to specific column
+lxa board add-item owner/repo#123 --column "Backlog"
+
+# Add to a specific board
+lxa board add-item owner/repo#123 --board my-project
+
+# Preview without making changes
+lxa board add-item owner/repo#123 --dry-run
+```
+
+This command is particularly useful for:
+- **Project-scoped boards**: Where items must be added manually
+- **Adding items from repos not in your watched list**
+- **Bulk importing specific items**
 
 ### `lxa board templates`
 


### PR DESCRIPTION
This PR updates documentation to cover features added in today's commits that were missing from the README.

## Analysis of Today's Commits

| Commit | Feature | README Status |
|--------|---------|---------------|
| add63ed | Project-scoped boards (`--scope`, `--overview`) | **Added** |
| bf112d5 | PR list, repo management, board rename/rm | Already documented |
| de513f8 | Verbosity control (`--verbosity`, `--timestamps`) | **Added** |
| e3ff7d8 | `lxa board add-item` command | **Added** |
| 86e8b8f | Auto-discovery scan, `sync-config` | Partially documented, **Enhanced** |
| ad19ea7 | `lxa run` command, global config | Already documented |
| 2f15d2d | Background jobs (`--background` on implement/refine) | **Added** |

## Documentation Updates Made

### README.md
1. **Single Iteration Mode**: Added `--background` and `--job-name` examples for `lxa implement`
2. **PR Refinement Mode**: Added `--background` example for `lxa refine`
3. **New "Output Verbosity" section**: Documents `--verbosity` (quiet/normal/verbose) and `--timestamps` flags
4. **Board Management**: 
   - Added project-scoped board example with `--scope project --overview URL`
   - Added `lxa board add-item` command examples
   - Added `lxa board sync-config` mention
   - Added "Board Scopes" explanation

### doc/reference/board-management.md
1. **`lxa board init`**: Added options table with `--scope` and `--overview`, plus detailed Board Scopes explanation
2. **New `lxa board add-item` section**: Full command documentation with examples

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/40a0be4f-7e82-4e16-bb64-d1127fc14807)