### PR TITLE
feat: Implement lxa review command for reviewer-centric PR queue

### DIFF
--- a/.pr/review-command-design.md
+++ b/.pr/review-command-design.md
@@ -1,0 +1,318 @@
+# Review Command Design
+
+## Overview
+
+A new `lxa review` command that provides a **reviewer-centric view** of your GitHub
+review queue. While `lxa pr list` answers "What's happening with my PRs?", 
+`lxa review` answers "What PRs need my review attention?"
+
+## Goals
+
+1. **Actionable** — Default view shows only PRs that need your attention
+2. **Contextual** — History string shows how you got to the current state
+3. **Prioritized** — Longest-waiting reviews surface first
+4. **Consistent** — Same table format and history string as `lxa pr list`
+
+## Non-Goals
+
+- Mention tracking (PRs where you're @mentioned but not a reviewer)
+- Review assignment suggestions
+- Cross-repo review load balancing
+
+## User Interface
+
+### Basic Usage
+
+```bash
+lxa review              # Show PRs needing my review action (default)
+lxa review --all        # Include PRs where ball is not in my court
+```
+
+### Default View
+
+Shows only PRs that need YOUR action:
+
+```
+ Repo           PR    History   Status      Wait    CI       💬   Author   Last
+─────────────────────────────────────────────────────────────────────────────────
+ owner/repo    #142   OHrF      re-review   3h      green     2   alice    1h ago
+ owner/repo2   #51    OH        review      2d      green    --   bob      2h ago
+
+Showing 2 PRs needing your review
+```
+
+### Full View (`--all`)
+
+Adds PRs where the ball is in the author's court:
+
+```
+ Repo           PR    History   Status      Wait    CI       💬   Author   Last
+─────────────────────────────────────────────────────────────────────────────────
+ owner/repo    #142   OHrF      re-review   3h      green     2   alice    1h ago
+ owner/repo2   #51    OH        review      2d      green    --   bob      2h ago
+ owner/repo    #28    OHr       hold        1d      green    --   dave     1d ago
+ owner/repo    #15    OHa       approved    2d      green    --   eve      2d ago
+
+Showing 4 PRs (2 need action)
+```
+
+### CLI Options
+
+```
+lxa review [OPTIONS]
+
+Options:
+  --all, -A               Include approved and hold PRs (default: only actionable)
+  --author USER           Filter by PR author
+  --repo OWNER/REPO       Filter by repo (can specify multiple times)
+  --board NAME, -b NAME   Use repos from specified board
+  --limit N, -n N         Maximum PRs to show (default: 100)
+  --title, -t             Include PR titles in output
+  --help, -h              Show help
+```
+
+### Example Workflows
+
+```bash
+# Daily review check - see what's waiting on you
+lxa review
+
+# Check a specific author's PRs
+lxa review --author alice
+
+# Check reviews across a project board
+lxa review --board my-project
+
+# Full reviewer dashboard with titles
+lxa review --all --title
+```
+
+## Technical Design
+
+### 1. Column Definitions
+
+| Column | Description |
+|--------|-------------|
+| **Repo** | Repository name |
+| **PR** | PR number |
+| **History** | Compact timeline string (lowercase = your actions, uppercase = others) |
+| **Status** | Your review status (see below) |
+| **Wait** | How long this has been waiting (varies by status) |
+| **CI** | CI status: `green`, `red`, `pending`, `conflict` |
+| **💬** | Unresolved review threads |
+| **Author** | PR author |
+| **Last** | Time since last activity on the PR |
+
+### 2. History String
+
+The history string is reused from `lxa pr list` with the **reviewer as the 
+reference user**:
+
+- **Lowercase** = your actions (as reviewer)
+- **Uppercase** = others' actions (author, other reviewers)
+
+| Code | Meaning |
+|------|---------|
+| `o/O` | Opened |
+| `h/H` | Help requested (review requested) |
+| `r/R` | Review with changes requested |
+| `a/A` | Approved |
+| `c/C` | Comment |
+| `f/F` | Fix (commits pushed after review) |
+| `m/M` | Merged |
+| `k/K` | Killed (closed without merge) |
+
+#### Reading History as a Reviewer
+
+| History | Interpretation |
+|---------|----------------|
+| `OH` | They Opened, requested Help → I need to do initial review |
+| `OHrF` | ...I reviewed (changes), they Fixed → I need to re-review |
+| `OHa` | ...I approved → Done |
+| `OHrFa` | ...I reviewed, they fixed, I approved → Done |
+| `OHRA` | ...someone else Reviewed, someone Approved → Someone else handled it |
+
+### 3. Status Values
+
+| Status | Meaning | Your Action | Wait = |
+|--------|---------|-------------|--------|
+| `review` | Requested, not yet reviewed | Do initial review | Time since requested |
+| `re-review` | New commits since your last review | Re-review changes | Time since new commits |
+| `hold` | You requested changes, author hasn't pushed | Wait | Time since you requested changes |
+| `approved` | You approved, not yet merged | None | Time since you approved |
+
+### 4. Visual Styling
+
+**Status colors:**
+- `review`, `re-review` → **yellow** (needs attention)
+- `hold`, `approved` → **dim** (info only, no action needed)
+
+**Wait time urgency:**
+- `> 48h` → **red** (critical)
+- `> 24h` → **yellow** (warning)  
+- `< 24h` → default
+
+**Sorting:**
+Default sort: By status priority (review → re-review → hold → approved), 
+then by Wait time descending (longest-waiting first)
+
+### 5. Data Model
+
+```python
+class ReviewStatus(Enum):
+    """Reviewer's status on a PR."""
+    REVIEW = "review"        # Needs initial review
+    RE_REVIEW = "re-review"  # Needs re-review after changes
+    HOLD = "hold"            # Waiting on author
+    APPROVED = "approved"    # Reviewer approved
+
+@dataclass
+class ReviewInfo:
+    """PR information from reviewer's perspective."""
+    repo: str
+    number: int
+    title: str
+    history: str
+    status: ReviewStatus
+    wait_seconds: float      # Time waiting for reviewer action
+    ci_status: CIStatus
+    unresolved_thread_count: int
+    author: str
+    last_activity: datetime
+    
+    @property
+    def needs_action(self) -> bool:
+        """True if reviewer needs to take action."""
+        return self.status in (ReviewStatus.REVIEW, ReviewStatus.RE_REVIEW)
+```
+
+### 6. Status Computation Logic
+
+```python
+def compute_review_status(
+    timeline_events: list[TimelineEvent],
+    reviewer: str,
+) -> tuple[ReviewStatus, datetime]:
+    """Compute reviewer status and wait time from timeline.
+    
+    Returns:
+        Tuple of (status, wait_start_time)
+    """
+    # Find reviewer's reviews in timeline
+    my_reviews = [e for e in timeline_events 
+                  if e.actor.lower() == reviewer.lower()
+                  and e.action in (ActionType.REVIEW, ActionType.APPROVED)]
+    
+    if not my_reviews:
+        # Never reviewed - find when review was requested
+        request_events = [e for e in timeline_events 
+                         if e.action == ActionType.HELP]
+        if request_events:
+            return (ReviewStatus.REVIEW, request_events[-1].timestamp)
+        # Fallback to PR creation time
+        return (ReviewStatus.REVIEW, timeline_events[0].timestamp)
+    
+    last_review = my_reviews[-1]
+    
+    # Check if I approved
+    if last_review.action == ActionType.APPROVED:
+        return (ReviewStatus.APPROVED, last_review.timestamp)
+    
+    # I requested changes - check if author pushed since
+    commits_after_review = [e for e in timeline_events
+                           if e.action == ActionType.FIX
+                           and e.timestamp > last_review.timestamp]
+    
+    if commits_after_review:
+        return (ReviewStatus.RE_REVIEW, commits_after_review[0].timestamp)
+    
+    return (ReviewStatus.HOLD, last_review.timestamp)
+```
+
+### 7. Data Fetching
+
+#### GitHub Search Queries
+
+```python
+def fetch_review_queue(reviewer: str, repos: list[str] | None) -> list[ReviewInfo]:
+    """Fetch PRs for reviewer's queue."""
+    
+    # Query 1: PRs where reviewer is requested (pending reviews)
+    requested_query = f"is:pr is:open review-requested:{reviewer}"
+    
+    # Query 2: PRs reviewer has reviewed (for re-review detection)
+    reviewed_query = f"is:pr is:open reviewed-by:{reviewer}"
+    
+    # Combine results, deduplicate by PR
+    # Process each PR to compute ReviewInfo
+```
+
+#### Reusable Components
+
+The existing `PR_FIELDS_FRAGMENT` GraphQL fragment already fetches:
+- Timeline items (reviews, commits, comments)
+- CI status
+- Unresolved threads
+- Author info
+
+The `process_pr_data()` function can be adapted to generate `ReviewInfo` objects.
+
+## Implementation Plan
+
+### Milestone 1: Core Data Model and Status Logic
+
+**Goal:** Implement the reviewer status computation logic.
+
+**Files:**
+- `src/review/models.py` - `ReviewStatus` enum and `ReviewInfo` dataclass
+- `src/review/status.py` - Status computation logic
+- `tests/review/test_status.py` - Unit tests for status computation
+
+**Acceptance Criteria:**
+- All status computation tests pass
+- Correctly identifies: review, re-review, hold, approved states
+- Correctly computes wait time for each status
+
+### Milestone 2: GitHub API Integration
+
+**Goal:** Fetch and process PR data for review queue.
+
+**Files:**
+- `src/review/github_api.py` - ReviewClient class
+- `tests/review/test_github_api.py` - API integration tests
+
+**Acceptance Criteria:**
+- Can fetch PRs where user is requested reviewer
+- Can fetch PRs user has reviewed
+- Combines and deduplicates results
+- Processes timeline to compute status
+
+### Milestone 3: CLI Command
+
+**Goal:** Implement the `lxa review` command with table output.
+
+**Files:**
+- `src/review/cli/__init__.py` - CLI exports
+- `src/review/cli/list_cmd.py` - Main command implementation
+- `src/__main__.py` - Register command in CLI
+- `tests/review/test_cli.py` - CLI tests
+
+**Acceptance Criteria:**
+- `lxa review` shows actionable PRs
+- `lxa review --all` shows all PRs
+- All CLI options work (--author, --repo, --board, --limit, --title)
+- Table output matches design spec
+- Status colors and wait time urgency colors applied
+
+### Milestone 4: Polish and Documentation
+
+**Goal:** Finalize UX details and add documentation.
+
+**Tasks:**
+- Add help text for all options
+- Update README with `lxa review` usage
+- Add to AGENTS.md knowledge base
+
+**Acceptance Criteria:**
+- `lxa review --help` shows clear usage info
+- Documentation covers common workflows

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1545,6 +1545,54 @@ Configuration:
         help="Show weekly merge/age graph (only works with --merged)",
     )
 
+    # review command - reviewer's view of PR queue
+    review_parser = subparsers.add_parser(
+        "review",
+        help="Show PRs needing your review attention",
+        description="Show PRs from a reviewer's perspective. "
+        "Default shows only PRs that need your review action.",
+    )
+    review_parser.add_argument(
+        "--all",
+        "-A",
+        dest="all_reviews",
+        action="store_true",
+        help="Include approved and hold PRs (default: only actionable)",
+    )
+    review_parser.add_argument(
+        "--author",
+        metavar="USER",
+        help="Filter by PR author",
+    )
+    review_parser.add_argument(
+        "--repo",
+        dest="repos",
+        action="append",
+        metavar="OWNER/REPO",
+        help="Filter by repo (can be specified multiple times)",
+    )
+    review_parser.add_argument(
+        "--board",
+        "-b",
+        dest="board_name",
+        metavar="NAME",
+        help="Use repos from specified board",
+    )
+    review_parser.add_argument(
+        "--limit",
+        "-n",
+        type=int,
+        default=100,
+        help="Maximum number of PRs to show (default: 100)",
+    )
+    review_parser.add_argument(
+        "--title",
+        "-t",
+        dest="show_title",
+        action="store_true",
+        help="Show PR titles",
+    )
+
     # repo command
     repo_parser = subparsers.add_parser(
         "repo",
@@ -1761,6 +1809,19 @@ Configuration:
                 show_title=args.show_title,
                 show_graph=args.show_graph,
             )
+
+    # Handle review command
+    if args.command == "review":
+        from src.review.cli import cmd_list as review_cmd_list
+
+        return review_cmd_list(
+            all_reviews=args.all_reviews,
+            author=args.author,
+            repos=args.repos,
+            board_name=args.board_name,
+            limit=args.limit,
+            show_title=args.show_title,
+        )
 
     # Handle repo command
     if args.command == "repo":

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1560,6 +1560,12 @@ Configuration:
         help="Include approved and hold PRs (default: only actionable)",
     )
     review_parser.add_argument(
+        "--reviewer",
+        "-r",
+        metavar="USER",
+        help="Show review queue for specified user (default: current user)",
+    )
+    review_parser.add_argument(
         "--author",
         metavar="USER",
         help="Filter by PR author",
@@ -1816,6 +1822,7 @@ Configuration:
 
         return review_cmd_list(
             all_reviews=args.all_reviews,
+            reviewer=args.reviewer,
             author=args.author,
             repos=args.repos,
             board_name=args.board_name,

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1571,6 +1571,13 @@ Configuration:
         help="Filter by PR author",
     )
     review_parser.add_argument(
+        "--exclude-author",
+        "-X",
+        dest="exclude_authors",
+        metavar="USERS",
+        help="Comma-separated list of authors to exclude (e.g., dependabot[bot],renovate[bot])",
+    )
+    review_parser.add_argument(
         "--repo",
         dest="repos",
         action="append",
@@ -1845,10 +1852,16 @@ Configuration:
         if not review_states:
             review_states.append("open")
 
+        # Parse exclude_authors from comma-separated string
+        exclude_authors: list[str] | None = None
+        if args.exclude_authors:
+            exclude_authors = [a.strip() for a in args.exclude_authors.split(",") if a.strip()]
+
         return review_cmd_list(
             all_reviews=args.all_reviews,
             reviewer=args.reviewer,
             author=args.author,
+            exclude_authors=exclude_authors,
             repos=args.repos,
             board_name=args.board_name,
             limit=args.limit,

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1598,6 +1598,20 @@ Configuration:
         action="store_true",
         help="Show PR titles",
     )
+    review_parser.add_argument(
+        "--merged",
+        "-M",
+        dest="include_merged",
+        action="store_true",
+        help="Show merged PRs you've reviewed",
+    )
+    review_parser.add_argument(
+        "--closed",
+        "-C",
+        dest="include_closed",
+        action="store_true",
+        help="Show closed (unmerged) PRs you've reviewed",
+    )
 
     # repo command
     repo_parser = subparsers.add_parser(
@@ -1820,6 +1834,17 @@ Configuration:
     if args.command == "review":
         from src.review.cli import cmd_list as review_cmd_list
 
+        # Build states list based on flags
+        # If --merged or --closed specified, use those; otherwise default to open
+        review_states: list[str] = []
+        if args.include_merged:
+            review_states.append("merged")
+        if args.include_closed:
+            review_states.append("closed")
+        # If no historical flags, default to open
+        if not review_states:
+            review_states.append("open")
+
         return review_cmd_list(
             all_reviews=args.all_reviews,
             reviewer=args.reviewer,
@@ -1828,6 +1853,7 @@ Configuration:
             board_name=args.board_name,
             limit=args.limit,
             show_title=args.show_title,
+            states=review_states,
         )
 
     # Handle repo command

--- a/src/review/__init__.py
+++ b/src/review/__init__.py
@@ -1,0 +1,5 @@
+"""Review command module for reviewer-centric PR queue management."""
+
+from src.review.models import ReviewInfo, ReviewStatus
+
+__all__ = ["ReviewStatus", "ReviewInfo"]

--- a/src/review/cli/__init__.py
+++ b/src/review/cli/__init__.py
@@ -1,0 +1,5 @@
+"""CLI commands for review queue."""
+
+from src.review.cli.list_cmd import cmd_list
+
+__all__ = ["cmd_list"]

--- a/src/review/cli/list_cmd.py
+++ b/src/review/cli/list_cmd.py
@@ -23,6 +23,7 @@ def cmd_list(
     all_reviews: bool = False,
     reviewer: str | None = None,
     author: str | None = None,
+    exclude_authors: list[str] | None = None,
     repos: list[str] | None = None,
     board_name: str | None = None,
     limit: int = 100,
@@ -35,6 +36,7 @@ def cmd_list(
         all_reviews: Include approved and hold PRs (default: only actionable)
         reviewer: GitHub username to show queue for (default: current user)
         author: Filter by PR author
+        exclude_authors: List of authors to exclude (e.g., dependabot[bot])
         repos: List of repos to filter by (owner/repo format)
         board_name: Board to get repos from (default: default board)
         limit: Maximum number of PRs to show
@@ -56,6 +58,7 @@ def cmd_list(
                 reviewer=resolved_reviewer,
                 repos=target_repos,
                 author=author,
+                exclude_authors=exclude_authors,
                 limit=limit,
                 include_all=all_reviews,
                 states=states,

--- a/src/review/cli/list_cmd.py
+++ b/src/review/cli/list_cmd.py
@@ -44,11 +44,14 @@ def cmd_list(
     """
     try:
         with ReviewClient() as client:
+            # Resolve reviewer to actual username (needed for legend)
+            resolved_reviewer = reviewer if reviewer else client.get_current_user()
+
             # Get repos from board if not specified explicitly
             target_repos = _get_repos(repos, board_name)
 
             result = client.list_reviews(
-                reviewer=reviewer,
+                reviewer=resolved_reviewer,
                 repos=target_repos,
                 author=author,
                 limit=limit,
@@ -65,7 +68,7 @@ def cmd_list(
                     console.print(f"[dim]No PRs needing {target_possessive} review.[/]")
                 return 0
 
-            _print_review_table(result.reviews, show_title=show_title)
+            _print_review_table(result.reviews, reviewer=resolved_reviewer, show_title=show_title)
 
             # Print summary
             if all_reviews:
@@ -108,7 +111,9 @@ def _get_repos(
     return board_repos if board_repos else None
 
 
-def _print_review_table(reviews: list[ReviewInfo], *, show_title: bool = False) -> None:
+def _print_review_table(
+    reviews: list[ReviewInfo], *, reviewer: str, show_title: bool = False
+) -> None:
     """Print reviews in a formatted table."""
     table = Table(box=box.SIMPLE, show_header=True, header_style="bold")
 
@@ -145,6 +150,7 @@ def _print_review_table(reviews: list[ReviewInfo], *, show_title: bool = False) 
         table.add_row(*row)
 
     console.print(table)
+    console.print(f"\n[dim]History: lowercase={reviewer}, UPPERCASE=others[/]")
 
 
 def _format_history(history: str) -> str:

--- a/src/review/cli/list_cmd.py
+++ b/src/review/cli/list_cmd.py
@@ -1,7 +1,6 @@
 """Review list command - show reviewer's PR queue."""
 
 import logging
-import traceback
 
 from rich import box
 from rich.console import Console
@@ -74,7 +73,7 @@ def cmd_list(
             return 0
 
     except Exception as e:
-        logger.debug("Full traceback:\n%s", traceback.format_exc())
+        logger.exception("Error listing reviews:")
         console.print(f"[red]Error:[/] {e}")
         console.print("[dim]Run with --verbose for full traceback[/]")
         return 1

--- a/src/review/cli/list_cmd.py
+++ b/src/review/cli/list_cmd.py
@@ -27,6 +27,7 @@ def cmd_list(
     board_name: str | None = None,
     limit: int = 100,
     show_title: bool = False,
+    states: list[str] | None = None,
 ) -> int:
     """List PRs needing review with status visualization.
 
@@ -38,6 +39,7 @@ def cmd_list(
         board_name: Board to get repos from (default: default board)
         limit: Maximum number of PRs to show
         show_title: Include PR titles in output
+        states: List of states to include ("open", "merged", "closed")
 
     Returns:
         Exit code (0 for success)
@@ -56,13 +58,23 @@ def cmd_list(
                 author=author,
                 limit=limit,
                 include_all=all_reviews,
+                states=states,
             )
 
             # Determine whose queue we're showing for user-facing messages
             target_possessive = f"{reviewer}'s" if reviewer else "your"
 
+            # Determine if we're showing historical PRs
+            states_set = set(states or ["open"])
+            showing_historical = "merged" in states_set or "closed" in states_set
+            showing_open = "open" in states_set
+
             if not result.reviews:
-                if all_reviews:
+                if showing_historical and not showing_open:
+                    console.print(
+                        f"[dim]No historical PRs found that {resolved_reviewer} reviewed.[/]"
+                    )
+                elif all_reviews:
                     console.print(f"[dim]No PRs found in {target_possessive} review queue.[/]")
                 else:
                     console.print(f"[dim]No PRs needing {target_possessive} review.[/]")
@@ -71,7 +83,9 @@ def cmd_list(
             _print_review_table(result.reviews, reviewer=resolved_reviewer, show_title=show_title)
 
             # Print summary
-            if all_reviews:
+            if showing_historical and not showing_open:
+                console.print(f"\n[dim]Showing {len(result.reviews)} historical PRs[/]")
+            elif all_reviews:
                 console.print(
                     f"\n[dim]Showing {len(result.reviews)} PRs "
                     f"({result.action_count} need action)[/]"
@@ -163,6 +177,8 @@ def _format_status(status: ReviewStatus) -> str:
 
     - review, re-review: yellow (needs attention)
     - hold, approved: dim (info only)
+    - merged: magenta (historical)
+    - closed: dim (historical)
     """
     if status == ReviewStatus.REVIEW:
         return "[yellow]review[/]"
@@ -170,8 +186,12 @@ def _format_status(status: ReviewStatus) -> str:
         return "[yellow]re-review[/]"
     elif status == ReviewStatus.HOLD:
         return "[dim]hold[/]"
-    else:  # APPROVED
+    elif status == ReviewStatus.APPROVED:
         return "[dim]approved[/]"
+    elif status == ReviewStatus.MERGED:
+        return "[magenta]merged[/]"
+    else:  # CLOSED
+        return "[dim]closed[/]"
 
 
 def _format_wait_time(seconds: float, status: ReviewStatus) -> str:

--- a/src/review/cli/list_cmd.py
+++ b/src/review/cli/list_cmd.py
@@ -21,6 +21,7 @@ WAIT_WARNING_SECONDS = 24 * 3600  # 24 hours
 def cmd_list(
     *,
     all_reviews: bool = False,
+    reviewer: str | None = None,
     author: str | None = None,
     repos: list[str] | None = None,
     board_name: str | None = None,
@@ -31,6 +32,7 @@ def cmd_list(
 
     Args:
         all_reviews: Include approved and hold PRs (default: only actionable)
+        reviewer: GitHub username to show queue for (default: current user)
         author: Filter by PR author
         repos: List of repos to filter by (owner/repo format)
         board_name: Board to get repos from (default: default board)
@@ -46,17 +48,21 @@ def cmd_list(
             target_repos = _get_repos(repos, board_name)
 
             result = client.list_reviews(
+                reviewer=reviewer,
                 repos=target_repos,
                 author=author,
                 limit=limit,
                 include_all=all_reviews,
             )
 
+            # Determine whose queue we're showing for user-facing messages
+            target_possessive = f"{reviewer}'s" if reviewer else "your"
+
             if not result.reviews:
                 if all_reviews:
-                    console.print("[dim]No PRs found in your review queue.[/]")
+                    console.print(f"[dim]No PRs found in {target_possessive} review queue.[/]")
                 else:
-                    console.print("[dim]No PRs needing your review.[/]")
+                    console.print(f"[dim]No PRs needing {target_possessive} review.[/]")
                 return 0
 
             _print_review_table(result.reviews, show_title=show_title)
@@ -68,7 +74,9 @@ def cmd_list(
                     f"({result.action_count} need action)[/]"
                 )
             else:
-                console.print(f"\n[dim]Showing {len(result.reviews)} PRs needing your review[/]")
+                console.print(
+                    f"\n[dim]Showing {len(result.reviews)} PRs needing {target_possessive} review[/]"
+                )
 
             return 0
 

--- a/src/review/cli/list_cmd.py
+++ b/src/review/cli/list_cmd.py
@@ -1,0 +1,226 @@
+"""Review list command - show reviewer's PR queue."""
+
+import logging
+import traceback
+
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+from src.pr.models import CIStatus
+from src.review.github_api import ReviewClient
+from src.review.models import ReviewInfo, ReviewStatus
+
+console = Console()
+logger = logging.getLogger(__name__)
+
+# Wait time thresholds (in seconds)
+WAIT_CRITICAL_SECONDS = 48 * 3600  # 48 hours
+WAIT_WARNING_SECONDS = 24 * 3600  # 24 hours
+
+
+def cmd_list(
+    *,
+    all_reviews: bool = False,
+    author: str | None = None,
+    repos: list[str] | None = None,
+    board_name: str | None = None,
+    limit: int = 100,
+    show_title: bool = False,
+) -> int:
+    """List PRs needing review with status visualization.
+
+    Args:
+        all_reviews: Include approved and hold PRs (default: only actionable)
+        author: Filter by PR author
+        repos: List of repos to filter by (owner/repo format)
+        board_name: Board to get repos from (default: default board)
+        limit: Maximum number of PRs to show
+        show_title: Include PR titles in output
+
+    Returns:
+        Exit code (0 for success)
+    """
+    try:
+        with ReviewClient() as client:
+            # Get repos from board if not specified explicitly
+            target_repos = _get_repos(repos, board_name)
+
+            result = client.list_reviews(
+                repos=target_repos,
+                author=author,
+                limit=limit,
+                include_all=all_reviews,
+            )
+
+            if not result.reviews:
+                if all_reviews:
+                    console.print("[dim]No PRs found in your review queue.[/]")
+                else:
+                    console.print("[dim]No PRs needing your review.[/]")
+                return 0
+
+            _print_review_table(result.reviews, show_title=show_title)
+
+            # Print summary
+            if all_reviews:
+                console.print(
+                    f"\n[dim]Showing {len(result.reviews)} PRs "
+                    f"({result.action_count} need action)[/]"
+                )
+            else:
+                console.print(f"\n[dim]Showing {len(result.reviews)} PRs needing your review[/]")
+
+            return 0
+
+    except Exception as e:
+        logger.debug("Full traceback:\n%s", traceback.format_exc())
+        console.print(f"[red]Error:[/] {e}")
+        console.print("[dim]Run with --verbose for full traceback[/]")
+        return 1
+
+
+def _get_repos(
+    repos: list[str] | None,
+    board_name: str | None,
+) -> list[str] | None:
+    """Get list of repos to query.
+
+    Priority:
+    1. Explicit --repo flags
+    2. Board repos (from --board or default board)
+    3. None (all GitHub)
+    """
+    if repos:
+        return repos
+
+    # Always try to use board repos by default
+    from src.pr.config import get_repos
+
+    board_repos = get_repos(board_name)
+    return board_repos if board_repos else None
+
+
+def _print_review_table(reviews: list[ReviewInfo], *, show_title: bool = False) -> None:
+    """Print reviews in a formatted table."""
+    table = Table(box=box.SIMPLE, show_header=True, header_style="bold")
+
+    table.add_column("Repo", style="cyan", no_wrap=True)
+    table.add_column("PR", justify="right", no_wrap=True)
+    if show_title:
+        table.add_column("Title", no_wrap=True, overflow="ellipsis", max_width=35)
+    table.add_column("History", no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Wait", no_wrap=True)
+    table.add_column("CI", no_wrap=True)
+    table.add_column("💬", justify="right", no_wrap=True)
+    table.add_column("Author", no_wrap=True)
+    table.add_column("Last", no_wrap=True)
+
+    for review in reviews:
+        row = [
+            review.repo,
+            f"#{review.number}",
+        ]
+        if show_title:
+            row.append(review.title or "")
+        row.extend(
+            [
+                _format_history(review.history),
+                _format_status(review.status),
+                _format_wait_time(review.wait_seconds, review.status),
+                _format_ci_status(review.ci_status),
+                _format_unresolved_threads(review.unresolved_thread_count),
+                review.author,
+                _format_relative_time(review.last_activity),
+            ]
+        )
+        table.add_row(*row)
+
+    console.print(table)
+
+
+def _format_history(history: str) -> str:
+    """Format history string."""
+    return history
+
+
+def _format_status(status: ReviewStatus) -> str:
+    """Format review status with color.
+
+    - review, re-review: yellow (needs attention)
+    - hold, approved: dim (info only)
+    """
+    if status == ReviewStatus.REVIEW:
+        return "[yellow]review[/]"
+    elif status == ReviewStatus.RE_REVIEW:
+        return "[yellow]re-review[/]"
+    elif status == ReviewStatus.HOLD:
+        return "[dim]hold[/]"
+    else:  # APPROVED
+        return "[dim]approved[/]"
+
+
+def _format_wait_time(seconds: float, status: ReviewStatus) -> str:
+    """Format wait time with urgency colors.
+
+    - > 48h: red (critical)
+    - > 24h: yellow (warning)
+    - < 24h: default
+    """
+    duration = _format_duration(seconds)
+
+    # Only colorize for actionable statuses
+    if status not in (ReviewStatus.REVIEW, ReviewStatus.RE_REVIEW):
+        return f"[dim]{duration}[/]"
+
+    if seconds > WAIT_CRITICAL_SECONDS:
+        return f"[red]{duration}[/]"
+    elif seconds > WAIT_WARNING_SECONDS:
+        return f"[yellow]{duration}[/]"
+    else:
+        return duration
+
+
+def _format_ci_status(status: CIStatus) -> str:
+    """Format CI status with color."""
+    if status == CIStatus.GREEN:
+        return "[green]green[/]"
+    elif status == CIStatus.RED:
+        return "[red]red[/]"
+    elif status == CIStatus.CONFLICT:
+        return "[red]conflict[/]"
+    elif status == CIStatus.PENDING:
+        return "[yellow]pending[/]"
+    else:
+        return "[dim]--[/]"
+
+
+def _format_unresolved_threads(count: int) -> str:
+    """Format unresolved thread count."""
+    if count == 0:
+        return "[dim]--[/]"
+    return f"[yellow]{count}[/]"
+
+
+def _format_duration(seconds: float) -> str:
+    """Format duration in compact form (e.g., '3d', '2h', '45m')."""
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    elif seconds < 3600:
+        return f"{int(seconds / 60)}m"
+    elif seconds < 86400:
+        return f"{int(seconds / 3600)}h"
+    else:
+        days = int(seconds / 86400)
+        return f"{days}d"
+
+
+def _format_relative_time(dt) -> str:
+    """Format relative time (e.g., '3d ago', '2h ago')."""
+    from datetime import datetime
+
+    now = datetime.now(dt.tzinfo) if dt.tzinfo else datetime.now()
+    seconds = (now - dt).total_seconds()
+    duration = _format_duration(abs(seconds))
+    return f"{duration} ago"

--- a/src/review/github_api.py
+++ b/src/review/github_api.py
@@ -97,8 +97,8 @@ class ReviewClient:
             if review_info:
                 reviews.append(review_info)
 
-        # Sort by status priority, then by wait time (longest first)
-        reviews.sort(key=lambda r: (r.status_priority, -r.wait_seconds))
+        # Sort by most recently active first, then by status priority
+        reviews.sort(key=lambda r: (-r.last_activity.timestamp(), r.status_priority))
 
         # Filter to actionable if needed
         if not include_all:

--- a/src/review/github_api.py
+++ b/src/review/github_api.py
@@ -55,6 +55,7 @@ class ReviewClient:
         reviewer: str | None = None,
         repos: list[str] | None = None,
         author: str | None = None,
+        exclude_authors: list[str] | None = None,
         limit: int = 100,
         include_all: bool = False,
         states: list[str] | None = None,
@@ -69,6 +70,7 @@ class ReviewClient:
             reviewer: GitHub username (default: current user)
             repos: List of "owner/repo" strings to filter by
             author: Filter by PR author
+            exclude_authors: List of authors to exclude (e.g., dependabot[bot])
             limit: Maximum number of PRs to fetch
             include_all: If True, include all PRs; if False, only actionable ones
             states: List of states to include ("open", "merged", "closed")
@@ -78,6 +80,9 @@ class ReviewClient:
         """
         if reviewer is None:
             reviewer = self.get_current_user()
+
+        # Normalize exclude_authors to lowercase for case-insensitive matching
+        exclude_authors_lower = {a.lower() for a in exclude_authors} if exclude_authors else set()
 
         # Determine which states to fetch
         states_set = {s.lower() for s in (states or ["open"])}
@@ -121,7 +126,7 @@ class ReviewClient:
         # Process each PR to compute review status
         reviews: list[ReviewInfo] = []
         for pr_data in all_prs.values():
-            review_info = self._process_pr_for_reviewer(pr_data, reviewer)
+            review_info = self._process_pr_for_reviewer(pr_data, reviewer, exclude_authors_lower)
             if review_info:
                 reviews.append(review_info)
 
@@ -251,12 +256,14 @@ class ReviewClient:
         self,
         pr_data: dict,
         reviewer: str,
+        exclude_authors: set[str] | None = None,
     ) -> ReviewInfo | None:
         """Process raw PR data into ReviewInfo from reviewer's perspective.
 
         Args:
             pr_data: Raw PR data from GraphQL query
             reviewer: GitHub username of the reviewer
+            exclude_authors: Set of lowercased author names to exclude
 
         Returns:
             ReviewInfo object or None if PR should be excluded
@@ -271,6 +278,10 @@ class ReviewClient:
 
         # Skip if reviewer is the author
         if author.lower() == reviewer.lower():
+            return None
+
+        # Skip if author is in exclude list
+        if exclude_authors and author.lower() in exclude_authors:
             return None
 
         # Count unresolved review threads

--- a/src/review/github_api.py
+++ b/src/review/github_api.py
@@ -1,0 +1,263 @@
+"""GitHub API interactions for review queue."""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from src.board.github_api import GitHubClient, get_github_token, get_github_username
+from src.pr.github_api import PR_FIELDS_FRAGMENT
+from src.pr.history import (
+    _build_history_string,
+    _count_unresolved_threads,
+    _determine_ci_status,
+    _extract_timeline_events,
+    _find_last_activity,
+    _parse_datetime,
+)
+from src.review.models import ReviewInfo
+from src.review.status import compute_review_status
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ReviewListResult:
+    """Result of a review queue query."""
+
+    reviews: list[ReviewInfo] = field(default_factory=list)
+    total_count: int = 0
+    has_more: bool = False
+    action_count: int = 0  # PRs needing action
+
+
+class ReviewClient:
+    """Client for fetching PR data from reviewer's perspective."""
+
+    def __init__(self, token: str | None = None):
+        self.token = token or get_github_token()
+        self._client = GitHubClient(self.token)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "ReviewClient":
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
+    def get_current_user(self) -> str:
+        """Get the current authenticated user's login."""
+        return get_github_username() or self._client.get_authenticated_user()
+
+    def list_reviews(
+        self,
+        reviewer: str | None = None,
+        repos: list[str] | None = None,
+        author: str | None = None,
+        limit: int = 100,
+        include_all: bool = False,
+    ) -> ReviewListResult:
+        """List PRs from reviewer's perspective.
+
+        Combines PRs from two queries:
+        1. PRs where reviewer is requested (pending reviews)
+        2. PRs reviewer has reviewed (for re-review/hold/approved detection)
+
+        Args:
+            reviewer: GitHub username (default: current user)
+            repos: List of "owner/repo" strings to filter by
+            author: Filter by PR author
+            limit: Maximum number of PRs to fetch
+            include_all: If True, include all PRs; if False, only actionable ones
+
+        Returns:
+            ReviewListResult with processed ReviewInfo objects
+        """
+        if reviewer is None:
+            reviewer = self.get_current_user()
+
+        # Fetch PRs from both queries
+        requested_prs = self._fetch_requested_reviews(reviewer, repos, author, limit)
+        reviewed_prs = self._fetch_reviewed_prs(reviewer, repos, author, limit)
+
+        # Combine and deduplicate by PR identifier
+        all_prs: dict[str, dict] = {}
+        for pr_data in requested_prs + reviewed_prs:
+            repo = pr_data["repository"]["nameWithOwner"]
+            number = pr_data["number"]
+            key = f"{repo}#{number}"
+            if key not in all_prs:
+                all_prs[key] = pr_data
+
+        # Process each PR to compute review status
+        reviews: list[ReviewInfo] = []
+        for pr_data in all_prs.values():
+            review_info = self._process_pr_for_reviewer(pr_data, reviewer)
+            if review_info:
+                reviews.append(review_info)
+
+        # Sort by status priority, then by wait time (longest first)
+        reviews.sort(key=lambda r: (r.status_priority, -r.wait_seconds))
+
+        # Filter to actionable if needed
+        if not include_all:
+            reviews = [r for r in reviews if r.needs_action]
+
+        # Apply limit after filtering
+        reviews = reviews[:limit]
+
+        action_count = sum(1 for r in reviews if r.needs_action)
+
+        return ReviewListResult(
+            reviews=reviews,
+            total_count=len(reviews),
+            has_more=len(all_prs) > limit,
+            action_count=action_count,
+        )
+
+    def _fetch_requested_reviews(
+        self,
+        reviewer: str,
+        repos: list[str] | None,
+        author: str | None,
+        limit: int,
+    ) -> list[dict]:
+        """Fetch PRs where reviewer is requested."""
+        query_parts = [f"is:pr is:open review-requested:{reviewer}"]
+
+        if repos:
+            # Build repo filter - search API requires separate queries per repo
+            # but we can OR repos together with parentheses in a single query
+            repo_filter = " ".join(f"repo:{repo}" for repo in repos)
+            query_parts.append(repo_filter)
+
+        if author:
+            query_parts.append(f"author:{author}")
+
+        search_query = " ".join(query_parts)
+        return self._search_prs(search_query, limit)
+
+    def _fetch_reviewed_prs(
+        self,
+        reviewer: str,
+        repos: list[str] | None,
+        author: str | None,
+        limit: int,
+    ) -> list[dict]:
+        """Fetch open PRs that reviewer has reviewed."""
+        query_parts = [f"is:pr is:open reviewed-by:{reviewer}"]
+
+        if repos:
+            repo_filter = " ".join(f"repo:{repo}" for repo in repos)
+            query_parts.append(repo_filter)
+
+        if author:
+            query_parts.append(f"author:{author}")
+
+        search_query = " ".join(query_parts)
+        return self._search_prs(search_query, limit)
+
+    def _search_prs(self, search_query: str, limit: int) -> list[dict]:
+        """Execute a search query and return raw PR data."""
+        query = f"""
+        {PR_FIELDS_FRAGMENT}
+        query($query: String!, $limit: Int!, $cursor: String) {{
+            search(query: $query, type: ISSUE, first: $limit, after: $cursor) {{
+                issueCount
+                pageInfo {{
+                    hasNextPage
+                    endCursor
+                }}
+                nodes {{
+                    ... on PullRequest {{
+                        ...PRFields
+                    }}
+                }}
+            }}
+        }}
+        """
+
+        all_prs: list[dict] = []
+        cursor: str | None = None
+
+        while len(all_prs) < limit:
+            batch_limit = min(100, limit - len(all_prs))
+            data = self._client.graphql(
+                query,
+                {"query": search_query, "limit": batch_limit, "cursor": cursor},
+            )
+            search_result = data["search"]
+
+            for node in search_result["nodes"]:
+                if node:  # Skip null nodes
+                    all_prs.append(node)
+                    if len(all_prs) >= limit:
+                        break
+
+            page_info = search_result["pageInfo"]
+            if not page_info["hasNextPage"] or len(all_prs) >= limit:
+                break
+            cursor = page_info["endCursor"]
+
+        return all_prs
+
+    def _process_pr_for_reviewer(
+        self,
+        pr_data: dict,
+        reviewer: str,
+    ) -> ReviewInfo | None:
+        """Process raw PR data into ReviewInfo from reviewer's perspective.
+
+        Args:
+            pr_data: Raw PR data from GraphQL query
+            reviewer: GitHub username of the reviewer
+
+        Returns:
+            ReviewInfo object or None if PR should be excluded
+        """
+        # Extract basic fields
+        repo = pr_data["repository"]["nameWithOwner"]
+        number = pr_data["number"]
+        title = pr_data["title"]
+        author = pr_data["author"]["login"] if pr_data["author"] else "ghost"
+        created_at = _parse_datetime(pr_data["createdAt"])
+
+        # Skip if reviewer is the author
+        if author.lower() == reviewer.lower():
+            return None
+
+        # Count unresolved review threads
+        unresolved_thread_count = _count_unresolved_threads(pr_data)
+
+        # Determine CI status
+        ci_status = _determine_ci_status(pr_data)
+
+        # Process timeline into events
+        events = _extract_timeline_events(pr_data, author)
+
+        # Build history string from reviewer's perspective
+        history = _build_history_string(events, reviewer)
+
+        # Find last activity time
+        last_activity = _find_last_activity(events, created_at)
+
+        # Compute review status
+        status, wait_start = compute_review_status(events, reviewer)
+
+        # Calculate wait time in seconds
+        now = datetime.now(wait_start.tzinfo)
+        wait_seconds = (now - wait_start).total_seconds()
+
+        return ReviewInfo(
+            repo=repo,
+            number=number,
+            title=title,
+            history=history,
+            status=status,
+            wait_seconds=wait_seconds,
+            ci_status=ci_status,
+            unresolved_thread_count=unresolved_thread_count,
+            author=author,
+            last_activity=last_activity,
+        )

--- a/src/review/github_api.py
+++ b/src/review/github_api.py
@@ -14,7 +14,7 @@ from src.pr.history import (
     _find_last_activity,
     _parse_datetime,
 )
-from src.review.models import ReviewInfo
+from src.review.models import ReviewInfo, ReviewStatus
 from src.review.status import compute_review_status
 
 logger = logging.getLogger(__name__)
@@ -57,6 +57,7 @@ class ReviewClient:
         author: str | None = None,
         limit: int = 100,
         include_all: bool = False,
+        states: list[str] | None = None,
     ) -> ReviewListResult:
         """List PRs from reviewer's perspective.
 
@@ -70,6 +71,7 @@ class ReviewClient:
             author: Filter by PR author
             limit: Maximum number of PRs to fetch
             include_all: If True, include all PRs; if False, only actionable ones
+            states: List of states to include ("open", "merged", "closed")
 
         Returns:
             ReviewListResult with processed ReviewInfo objects
@@ -77,18 +79,44 @@ class ReviewClient:
         if reviewer is None:
             reviewer = self.get_current_user()
 
-        # Fetch PRs from both queries
-        requested_prs = self._fetch_requested_reviews(reviewer, repos, author, limit)
-        reviewed_prs = self._fetch_reviewed_prs(reviewer, repos, author, limit)
+        # Determine which states to fetch
+        states_set = {s.lower() for s in (states or ["open"])}
+        include_open = "open" in states_set
+        include_merged = "merged" in states_set
+        include_closed = "closed" in states_set
 
-        # Combine and deduplicate by PR identifier
         all_prs: dict[str, dict] = {}
-        for pr_data in requested_prs + reviewed_prs:
-            repo = pr_data["repository"]["nameWithOwner"]
-            number = pr_data["number"]
-            key = f"{repo}#{number}"
-            if key not in all_prs:
-                all_prs[key] = pr_data
+
+        # Fetch open PRs (both requested and reviewed)
+        if include_open:
+            requested_prs = self._fetch_requested_reviews(reviewer, repos, author, limit)
+            reviewed_prs = self._fetch_reviewed_prs(reviewer, repos, author, limit, state="open")
+            for pr_data in requested_prs + reviewed_prs:
+                repo = pr_data["repository"]["nameWithOwner"]
+                number = pr_data["number"]
+                key = f"{repo}#{number}"
+                if key not in all_prs:
+                    all_prs[key] = pr_data
+
+        # Fetch merged PRs
+        if include_merged:
+            merged_prs = self._fetch_reviewed_prs(reviewer, repos, author, limit, state="merged")
+            for pr_data in merged_prs:
+                repo = pr_data["repository"]["nameWithOwner"]
+                number = pr_data["number"]
+                key = f"{repo}#{number}"
+                if key not in all_prs:
+                    all_prs[key] = pr_data
+
+        # Fetch closed (unmerged) PRs
+        if include_closed:
+            closed_prs = self._fetch_reviewed_prs(reviewer, repos, author, limit, state="closed")
+            for pr_data in closed_prs:
+                repo = pr_data["repository"]["nameWithOwner"]
+                number = pr_data["number"]
+                key = f"{repo}#{number}"
+                if key not in all_prs:
+                    all_prs[key] = pr_data
 
         # Process each PR to compute review status
         reviews: list[ReviewInfo] = []
@@ -100,8 +128,8 @@ class ReviewClient:
         # Sort by most recently active first, then by status priority
         reviews.sort(key=lambda r: (-r.last_activity.timestamp(), r.status_priority))
 
-        # Filter to actionable if needed
-        if not include_all:
+        # Filter to actionable if needed (only for open PRs)
+        if not include_all and include_open and not include_merged and not include_closed:
             reviews = [r for r in reviews if r.needs_action]
 
         # Apply limit after filtering
@@ -144,9 +172,26 @@ class ReviewClient:
         repos: list[str] | None,
         author: str | None,
         limit: int,
+        state: str = "open",
     ) -> list[dict]:
-        """Fetch open PRs that reviewer has reviewed."""
-        query_parts = [f"is:pr is:open reviewed-by:{reviewer}"]
+        """Fetch PRs that reviewer has reviewed.
+
+        Args:
+            reviewer: GitHub username
+            repos: List of "owner/repo" strings to filter by
+            author: Filter by PR author
+            limit: Maximum number of PRs to fetch
+            state: PR state - "open", "merged", or "closed" (unmerged)
+        """
+        query_parts = [f"is:pr reviewed-by:{reviewer}"]
+
+        # Add state filter
+        if state == "open":
+            query_parts.append("is:open")
+        elif state == "merged":
+            query_parts.append("is:merged")
+        elif state == "closed":
+            query_parts.append("is:closed is:unmerged")
 
         if repos:
             repo_filter = " ".join(f"repo:{repo}" for repo in repos)
@@ -222,6 +267,7 @@ class ReviewClient:
         title = pr_data["title"]
         author = pr_data["author"]["login"] if pr_data["author"] else "ghost"
         created_at = _parse_datetime(pr_data["createdAt"])
+        pr_state = pr_data["state"]  # OPEN, MERGED, or CLOSED
 
         # Skip if reviewer is the author
         if author.lower() == reviewer.lower():
@@ -242,8 +288,17 @@ class ReviewClient:
         # Find last activity time
         last_activity = _find_last_activity(events, created_at)
 
-        # Compute review status
-        status, wait_start = compute_review_status(events, reviewer)
+        # For merged/closed PRs, use the PR state as status
+        # For open PRs, compute the review status
+        if pr_state == "MERGED":
+            status = ReviewStatus.MERGED
+            # Use closedAt for wait calculation
+            wait_start = _parse_datetime(pr_data.get("closedAt") or pr_data["createdAt"])
+        elif pr_state == "CLOSED":
+            status = ReviewStatus.CLOSED
+            wait_start = _parse_datetime(pr_data.get("closedAt") or pr_data["createdAt"])
+        else:
+            status, wait_start = compute_review_status(events, reviewer)
 
         # Calculate wait time in seconds
         now = datetime.now(wait_start.tzinfo)

--- a/src/review/models.py
+++ b/src/review/models.py
@@ -1,0 +1,47 @@
+"""Data models for reviewer-centric PR queue."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from src.pr.models import CIStatus
+
+
+class ReviewStatus(Enum):
+    """Reviewer's status on a PR."""
+
+    REVIEW = "review"  # Needs initial review
+    RE_REVIEW = "re-review"  # Needs re-review after changes
+    HOLD = "hold"  # Waiting on author
+    APPROVED = "approved"  # Reviewer approved
+
+
+@dataclass
+class ReviewInfo:
+    """PR information from reviewer's perspective."""
+
+    repo: str
+    number: int
+    title: str
+    history: str
+    status: ReviewStatus
+    wait_seconds: float  # Time waiting (meaning varies by status)
+    ci_status: CIStatus
+    unresolved_thread_count: int
+    author: str
+    last_activity: datetime
+
+    @property
+    def needs_action(self) -> bool:
+        """True if reviewer needs to take action."""
+        return self.status in (ReviewStatus.REVIEW, ReviewStatus.RE_REVIEW)
+
+    @property
+    def status_priority(self) -> int:
+        """Return sort priority for status (lower = higher priority)."""
+        return {
+            ReviewStatus.REVIEW: 0,
+            ReviewStatus.RE_REVIEW: 1,
+            ReviewStatus.HOLD: 2,
+            ReviewStatus.APPROVED: 3,
+        }.get(self.status, 99)

--- a/src/review/models.py
+++ b/src/review/models.py
@@ -14,6 +14,8 @@ class ReviewStatus(Enum):
     RE_REVIEW = "re-review"  # Needs re-review after changes
     HOLD = "hold"  # Waiting on author
     APPROVED = "approved"  # Reviewer approved
+    MERGED = "merged"  # PR was merged (historical)
+    CLOSED = "closed"  # PR was closed without merge (historical)
 
 
 @dataclass
@@ -44,4 +46,6 @@ class ReviewInfo:
             ReviewStatus.RE_REVIEW: 1,
             ReviewStatus.HOLD: 2,
             ReviewStatus.APPROVED: 3,
+            ReviewStatus.MERGED: 4,
+            ReviewStatus.CLOSED: 5,
         }.get(self.status, 99)

--- a/src/review/status.py
+++ b/src/review/status.py
@@ -55,6 +55,14 @@ def compute_review_status(
 
     # Check if reviewer approved
     if last_review.action == ActionType.APPROVED:
+        # Check if author pushed commits after approval
+        commits_after_approval = [
+            e
+            for e in timeline_events
+            if e.action == ActionType.FIX and e.timestamp > last_review.timestamp
+        ]
+        if commits_after_approval:
+            return (ReviewStatus.RE_REVIEW, commits_after_approval[0].timestamp)
         return (ReviewStatus.APPROVED, last_review.timestamp)
 
     # Reviewer requested changes - check if author pushed since

--- a/src/review/status.py
+++ b/src/review/status.py
@@ -1,0 +1,72 @@
+"""Status computation logic for reviewer perspective."""
+
+from datetime import datetime
+
+from src.pr.models import ActionType, TimelineEvent
+from src.review.models import ReviewStatus
+
+
+def compute_review_status(
+    timeline_events: list[TimelineEvent],
+    reviewer: str,
+) -> tuple[ReviewStatus, datetime]:
+    """Compute reviewer status and wait time from timeline.
+
+    The status determines what action (if any) the reviewer needs to take:
+    - REVIEW: Initial review needed (requested but not yet reviewed)
+    - RE_REVIEW: Re-review needed (new commits after previous review)
+    - HOLD: Waiting on author (reviewer requested changes, no new commits)
+    - APPROVED: Reviewer approved (no action needed)
+
+    Args:
+        timeline_events: List of timeline events from the PR (sorted by timestamp)
+        reviewer: GitHub username of the reviewer
+
+    Returns:
+        Tuple of (status, wait_start_time) where wait_start_time is when
+        the wait period began (meaning varies by status):
+        - REVIEW: Time since review was requested (or PR created)
+        - RE_REVIEW: Time since new commits were pushed
+        - HOLD: Time since reviewer requested changes
+        - APPROVED: Time since approval
+    """
+    # Find reviewer's reviews in timeline (reviews with changes requested or approvals)
+    my_reviews = [
+        e
+        for e in timeline_events
+        if e.actor.lower() == reviewer.lower()
+        and e.action in (ActionType.REVIEW, ActionType.APPROVED)
+    ]
+
+    if not my_reviews:
+        # Never reviewed - find when review was requested
+        request_events = [e for e in timeline_events if e.action == ActionType.HELP]
+        if request_events:
+            # Use the most recent request event for this reviewer
+            # (in case they were requested multiple times)
+            return (ReviewStatus.REVIEW, request_events[-1].timestamp)
+        # Fallback to PR creation time (first event)
+        if timeline_events:
+            return (ReviewStatus.REVIEW, timeline_events[0].timestamp)
+        # Edge case: no events at all
+        return (ReviewStatus.REVIEW, datetime.now(tz=None))
+
+    last_review = my_reviews[-1]
+
+    # Check if reviewer approved
+    if last_review.action == ActionType.APPROVED:
+        return (ReviewStatus.APPROVED, last_review.timestamp)
+
+    # Reviewer requested changes - check if author pushed since
+    commits_after_review = [
+        e
+        for e in timeline_events
+        if e.action == ActionType.FIX and e.timestamp > last_review.timestamp
+    ]
+
+    if commits_after_review:
+        # New commits after review - need re-review
+        return (ReviewStatus.RE_REVIEW, commits_after_review[0].timestamp)
+
+    # Requested changes but no new commits - waiting on author
+    return (ReviewStatus.HOLD, last_review.timestamp)

--- a/tests/review/__init__.py
+++ b/tests/review/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for review module."""

--- a/tests/review/test_cli.py
+++ b/tests/review/test_cli.py
@@ -282,6 +282,25 @@ class TestCmdList:
         result = cmd_list()
         assert result == 1
 
+    @patch("src.review.cli.list_cmd.ReviewClient")
+    @patch("src.review.cli.list_cmd._get_repos")
+    def test_passes_exclude_authors(self, mock_get_repos, mock_client_cls):
+        """Test that --exclude-author is passed to client."""
+        from src.review.cli.list_cmd import cmd_list
+        from src.review.github_api import ReviewListResult
+
+        mock_get_repos.return_value = None
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.list_reviews.return_value = ReviewListResult()
+        mock_client_cls.return_value = mock_client
+
+        cmd_list(exclude_authors=["dependabot[bot]", "renovate[bot]"])
+
+        call_kwargs = mock_client.list_reviews.call_args[1]
+        assert call_kwargs["exclude_authors"] == ["dependabot[bot]", "renovate[bot]"]
+
 
 class TestGetRepos:
     """Tests for _get_repos function."""

--- a/tests/review/test_cli.py
+++ b/tests/review/test_cli.py
@@ -239,6 +239,25 @@ class TestCmdList:
 
     @patch("src.review.cli.list_cmd.ReviewClient")
     @patch("src.review.cli.list_cmd._get_repos")
+    def test_passes_reviewer_filter(self, mock_get_repos, mock_client_cls):
+        """Test that --reviewer is passed to client."""
+        from src.review.cli.list_cmd import cmd_list
+        from src.review.github_api import ReviewListResult
+
+        mock_get_repos.return_value = None
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.list_reviews.return_value = ReviewListResult()
+        mock_client_cls.return_value = mock_client
+
+        cmd_list(reviewer="other-user")
+
+        call_kwargs = mock_client.list_reviews.call_args[1]
+        assert call_kwargs["reviewer"] == "other-user"
+
+    @patch("src.review.cli.list_cmd.ReviewClient")
+    @patch("src.review.cli.list_cmd._get_repos")
     def test_handles_error(self, mock_get_repos, mock_client_cls):
         """Test error handling."""
         from src.review.cli.list_cmd import cmd_list

--- a/tests/review/test_cli.py
+++ b/tests/review/test_cli.py
@@ -62,6 +62,16 @@ class TestFormatStatus:
         assert "dim" in result
         assert "approved" in result
 
+    def test_merged_magenta(self):
+        result = _format_status(ReviewStatus.MERGED)
+        assert "magenta" in result
+        assert "merged" in result
+
+    def test_closed_dim(self):
+        result = _format_status(ReviewStatus.CLOSED)
+        assert "dim" in result
+        assert "closed" in result
+
 
 class TestFormatWaitTime:
     """Tests for _format_wait_time function."""

--- a/tests/review/test_cli.py
+++ b/tests/review/test_cli.py
@@ -1,0 +1,285 @@
+"""Tests for review CLI command."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from src.pr.models import CIStatus
+from src.review.cli.list_cmd import (
+    WAIT_CRITICAL_SECONDS,
+    WAIT_WARNING_SECONDS,
+    _format_ci_status,
+    _format_duration,
+    _format_status,
+    _format_unresolved_threads,
+    _format_wait_time,
+)
+from src.review.models import ReviewInfo, ReviewStatus
+
+
+class TestFormatDuration:
+    """Tests for _format_duration function."""
+
+    def test_seconds(self):
+        assert _format_duration(30) == "30s"
+        assert _format_duration(59) == "59s"
+
+    def test_minutes(self):
+        assert _format_duration(60) == "1m"
+        assert _format_duration(90) == "1m"
+        assert _format_duration(3599) == "59m"
+
+    def test_hours(self):
+        assert _format_duration(3600) == "1h"
+        assert _format_duration(7200) == "2h"
+        assert _format_duration(86399) == "23h"
+
+    def test_days(self):
+        assert _format_duration(86400) == "1d"
+        assert _format_duration(172800) == "2d"
+        assert _format_duration(604800) == "7d"
+
+
+class TestFormatStatus:
+    """Tests for _format_status function."""
+
+    def test_review_yellow(self):
+        result = _format_status(ReviewStatus.REVIEW)
+        assert "yellow" in result
+        assert "review" in result
+
+    def test_re_review_yellow(self):
+        result = _format_status(ReviewStatus.RE_REVIEW)
+        assert "yellow" in result
+        assert "re-review" in result
+
+    def test_hold_dim(self):
+        result = _format_status(ReviewStatus.HOLD)
+        assert "dim" in result
+        assert "hold" in result
+
+    def test_approved_dim(self):
+        result = _format_status(ReviewStatus.APPROVED)
+        assert "dim" in result
+        assert "approved" in result
+
+
+class TestFormatWaitTime:
+    """Tests for _format_wait_time function."""
+
+    def test_critical_red_for_actionable(self):
+        # > 48 hours = critical
+        seconds = WAIT_CRITICAL_SECONDS + 1
+        result = _format_wait_time(seconds, ReviewStatus.REVIEW)
+        assert "red" in result
+
+    def test_warning_yellow_for_actionable(self):
+        # > 24 hours but < 48 hours = warning
+        seconds = WAIT_WARNING_SECONDS + 1
+        result = _format_wait_time(seconds, ReviewStatus.RE_REVIEW)
+        assert "yellow" in result
+
+    def test_normal_for_short_wait(self):
+        # < 24 hours = normal
+        seconds = WAIT_WARNING_SECONDS - 1
+        result = _format_wait_time(seconds, ReviewStatus.REVIEW)
+        assert "red" not in result
+        assert "yellow" not in result
+
+    def test_dim_for_non_actionable(self):
+        # Non-actionable statuses get dim regardless of time
+        result = _format_wait_time(WAIT_CRITICAL_SECONDS + 1, ReviewStatus.HOLD)
+        assert "dim" in result
+
+        result = _format_wait_time(WAIT_CRITICAL_SECONDS + 1, ReviewStatus.APPROVED)
+        assert "dim" in result
+
+
+class TestFormatCIStatus:
+    """Tests for _format_ci_status function."""
+
+    def test_green(self):
+        result = _format_ci_status(CIStatus.GREEN)
+        assert "green" in result
+
+    def test_red(self):
+        result = _format_ci_status(CIStatus.RED)
+        assert "red" in result
+
+    def test_conflict(self):
+        result = _format_ci_status(CIStatus.CONFLICT)
+        assert "red" in result
+        assert "conflict" in result
+
+    def test_pending(self):
+        result = _format_ci_status(CIStatus.PENDING)
+        assert "yellow" in result
+
+    def test_none(self):
+        result = _format_ci_status(CIStatus.NONE)
+        assert "dim" in result
+        assert "--" in result
+
+
+class TestFormatUnresolvedThreads:
+    """Tests for _format_unresolved_threads function."""
+
+    def test_zero_threads(self):
+        result = _format_unresolved_threads(0)
+        assert "dim" in result
+        assert "--" in result
+
+    def test_nonzero_threads(self):
+        result = _format_unresolved_threads(5)
+        assert "yellow" in result
+        assert "5" in result
+
+
+class TestCmdList:
+    """Tests for cmd_list function."""
+
+    @patch("src.review.cli.list_cmd.ReviewClient")
+    @patch("src.review.cli.list_cmd._get_repos")
+    def test_empty_result_no_action(self, mock_get_repos, mock_client_cls):
+        """Test output when no PRs need action."""
+        from src.review.cli.list_cmd import cmd_list
+        from src.review.github_api import ReviewListResult
+
+        mock_get_repos.return_value = None
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.list_reviews.return_value = ReviewListResult(
+            reviews=[],
+            total_count=0,
+            has_more=False,
+            action_count=0,
+        )
+        mock_client_cls.return_value = mock_client
+
+        result = cmd_list()
+        assert result == 0
+
+    @patch("src.review.cli.list_cmd.ReviewClient")
+    @patch("src.review.cli.list_cmd._get_repos")
+    def test_returns_reviews(self, mock_get_repos, mock_client_cls):
+        """Test that reviews are displayed."""
+        from src.review.cli.list_cmd import cmd_list
+        from src.review.github_api import ReviewListResult
+
+        mock_get_repos.return_value = None
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        now = datetime.now(UTC)
+        reviews = [
+            ReviewInfo(
+                repo="owner/repo",
+                number=42,
+                title="Test PR",
+                history="OHrF",
+                status=ReviewStatus.RE_REVIEW,
+                wait_seconds=3600.0,
+                ci_status=CIStatus.GREEN,
+                unresolved_thread_count=2,
+                author="alice",
+                last_activity=now,
+            )
+        ]
+        mock_client.list_reviews.return_value = ReviewListResult(
+            reviews=reviews,
+            total_count=1,
+            has_more=False,
+            action_count=1,
+        )
+        mock_client_cls.return_value = mock_client
+
+        result = cmd_list()
+        assert result == 0
+        mock_client.list_reviews.assert_called_once()
+
+    @patch("src.review.cli.list_cmd.ReviewClient")
+    @patch("src.review.cli.list_cmd._get_repos")
+    def test_passes_all_reviews_flag(self, mock_get_repos, mock_client_cls):
+        """Test that --all flag is passed to client."""
+        from src.review.cli.list_cmd import cmd_list
+        from src.review.github_api import ReviewListResult
+
+        mock_get_repos.return_value = None
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.list_reviews.return_value = ReviewListResult()
+        mock_client_cls.return_value = mock_client
+
+        cmd_list(all_reviews=True)
+
+        mock_client.list_reviews.assert_called_once()
+        call_kwargs = mock_client.list_reviews.call_args[1]
+        assert call_kwargs["include_all"] is True
+
+    @patch("src.review.cli.list_cmd.ReviewClient")
+    @patch("src.review.cli.list_cmd._get_repos")
+    def test_passes_author_filter(self, mock_get_repos, mock_client_cls):
+        """Test that --author is passed to client."""
+        from src.review.cli.list_cmd import cmd_list
+        from src.review.github_api import ReviewListResult
+
+        mock_get_repos.return_value = None
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.list_reviews.return_value = ReviewListResult()
+        mock_client_cls.return_value = mock_client
+
+        cmd_list(author="alice")
+
+        call_kwargs = mock_client.list_reviews.call_args[1]
+        assert call_kwargs["author"] == "alice"
+
+    @patch("src.review.cli.list_cmd.ReviewClient")
+    @patch("src.review.cli.list_cmd._get_repos")
+    def test_handles_error(self, mock_get_repos, mock_client_cls):
+        """Test error handling."""
+        from src.review.cli.list_cmd import cmd_list
+
+        mock_get_repos.return_value = None
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.list_reviews.side_effect = Exception("API error")
+        mock_client_cls.return_value = mock_client
+
+        result = cmd_list()
+        assert result == 1
+
+
+class TestGetRepos:
+    """Tests for _get_repos function."""
+
+    def test_explicit_repos_returned(self):
+        """Test that explicit repos take priority."""
+        from src.review.cli.list_cmd import _get_repos
+
+        repos = ["owner/repo1", "owner/repo2"]
+        result = _get_repos(repos, None)
+        assert result == repos
+
+    @patch("src.pr.config.get_repos")
+    def test_board_repos_used(self, mock_get_repos):
+        """Test that board repos are used when no explicit repos."""
+        from src.review.cli.list_cmd import _get_repos
+
+        mock_get_repos.return_value = ["board/repo1", "board/repo2"]
+        result = _get_repos(None, "my-board")
+        assert result == ["board/repo1", "board/repo2"]
+        mock_get_repos.assert_called_with("my-board")
+
+    @patch("src.pr.config.get_repos")
+    def test_no_repos_returns_none(self, mock_get_repos):
+        """Test that None is returned when no repos available."""
+        from src.review.cli.list_cmd import _get_repos
+
+        mock_get_repos.return_value = []
+        result = _get_repos(None, None)
+        assert result is None

--- a/tests/review/test_github_api.py
+++ b/tests/review/test_github_api.py
@@ -1,0 +1,297 @@
+"""Tests for review GitHub API integration."""
+
+from datetime import UTC, datetime
+
+from src.pr.models import CIStatus
+from src.review.github_api import ReviewClient
+from src.review.models import ReviewStatus
+
+
+class TestProcessPrForReviewer:
+    """Tests for _process_pr_for_reviewer method."""
+
+    def _make_pr_data(
+        self,
+        repo: str = "owner/repo",
+        number: int = 1,
+        title: str = "Test PR",
+        author: str = "alice",
+        created_at: str = "2024-01-01T00:00:00Z",
+        timeline_items: list | None = None,
+    ) -> dict:
+        """Helper to create mock PR data."""
+        return {
+            "repository": {"nameWithOwner": repo},
+            "number": number,
+            "title": title,
+            "author": {"login": author},
+            "createdAt": created_at,
+            "closedAt": None,
+            "state": "OPEN",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "reviewThreads": {"nodes": []},
+            "commits": {"nodes": []},
+            "timelineItems": {"nodes": timeline_items or []},
+        }
+
+    def test_basic_pr_processing(self):
+        """Test processing a simple PR."""
+        pr_data = self._make_pr_data(
+            timeline_items=[
+                {
+                    "__typename": "ReviewRequestedEvent",
+                    "createdAt": "2024-01-01T12:00:00Z",
+                    "actor": {"login": "alice"},
+                    "requestedReviewer": {"login": "bob"},
+                },
+            ]
+        )
+
+        # Create client but don't connect (we'll call private method directly)
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.repo == "owner/repo"
+        assert review_info.number == 1
+        assert review_info.title == "Test PR"
+        assert review_info.author == "alice"
+        assert review_info.status == ReviewStatus.REVIEW
+
+    def test_excludes_own_prs(self):
+        """Test that reviewer's own PRs are excluded."""
+        pr_data = self._make_pr_data(author="bob")
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is None
+
+    def test_case_insensitive_author_exclusion(self):
+        """Test that author exclusion is case-insensitive."""
+        pr_data = self._make_pr_data(author="BOB")
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is None
+
+    def test_re_review_status(self):
+        """Test PR that needs re-review after fixes."""
+        pr_data = self._make_pr_data(
+            timeline_items=[
+                {
+                    "__typename": "ReviewRequestedEvent",
+                    "createdAt": "2024-01-01T12:00:00Z",
+                    "actor": {"login": "alice"},
+                    "requestedReviewer": {"login": "bob"},
+                },
+                {
+                    "__typename": "PullRequestReview",
+                    "author": {"login": "bob"},
+                    "state": "CHANGES_REQUESTED",
+                    "createdAt": "2024-01-02T00:00:00Z",
+                    "comments": {"totalCount": 2},
+                },
+                {
+                    "__typename": "PullRequestCommit",
+                    "commit": {
+                        "author": {"user": {"login": "alice"}},
+                        "committedDate": "2024-01-03T00:00:00Z",
+                    },
+                },
+            ]
+        )
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.status == ReviewStatus.RE_REVIEW
+
+    def test_hold_status(self):
+        """Test PR in hold (waiting on author)."""
+        pr_data = self._make_pr_data(
+            timeline_items=[
+                {
+                    "__typename": "ReviewRequestedEvent",
+                    "createdAt": "2024-01-01T12:00:00Z",
+                    "actor": {"login": "alice"},
+                    "requestedReviewer": {"login": "bob"},
+                },
+                {
+                    "__typename": "PullRequestReview",
+                    "author": {"login": "bob"},
+                    "state": "CHANGES_REQUESTED",
+                    "createdAt": "2024-01-02T00:00:00Z",
+                    "comments": {"totalCount": 2},
+                },
+            ]
+        )
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.status == ReviewStatus.HOLD
+
+    def test_approved_status(self):
+        """Test PR that reviewer approved."""
+        pr_data = self._make_pr_data(
+            timeline_items=[
+                {
+                    "__typename": "PullRequestReview",
+                    "author": {"login": "bob"},
+                    "state": "APPROVED",
+                    "createdAt": "2024-01-02T00:00:00Z",
+                    "comments": {"totalCount": 0},
+                },
+            ]
+        )
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.status == ReviewStatus.APPROVED
+
+    def test_history_from_reviewer_perspective(self):
+        """Test that history string is built from reviewer's perspective."""
+        pr_data = self._make_pr_data(
+            timeline_items=[
+                {
+                    "__typename": "ReviewRequestedEvent",
+                    "createdAt": "2024-01-01T12:00:00Z",
+                    "actor": {"login": "alice"},
+                    "requestedReviewer": {"login": "bob"},
+                },
+                {
+                    "__typename": "PullRequestReview",
+                    "author": {"login": "bob"},
+                    "state": "CHANGES_REQUESTED",
+                    "createdAt": "2024-01-02T00:00:00Z",
+                    "comments": {"totalCount": 2},
+                },
+                {
+                    "__typename": "PullRequestCommit",
+                    "commit": {
+                        "author": {"user": {"login": "alice"}},
+                        "committedDate": "2024-01-03T00:00:00Z",
+                    },
+                },
+            ]
+        )
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        # From bob's perspective: O (alice opened), H (alice requested), r (bob reviewed), F (alice fixed)
+        # Note: lowercase 'r' = bob's action, uppercase 'F' = alice's action
+        assert "r" in review_info.history.lower()  # bob reviewed (lowercase r)
+        assert "F" in review_info.history  # alice fixed (uppercase F)
+
+    def test_unresolved_threads_counted(self):
+        """Test that unresolved review threads are counted."""
+        pr_data = self._make_pr_data()
+        pr_data["reviewThreads"] = {
+            "nodes": [
+                {"isResolved": False},
+                {"isResolved": True},
+                {"isResolved": False},
+            ]
+        }
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.unresolved_thread_count == 2
+
+    def test_ghost_author_handled(self):
+        """Test handling of deleted user (ghost author)."""
+        pr_data = self._make_pr_data()
+        pr_data["author"] = None  # Deleted user
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.author == "ghost"
+
+    def test_ci_status_green(self):
+        """Test CI status detection for passing checks."""
+        pr_data = self._make_pr_data()
+        pr_data["commits"] = {
+            "nodes": [
+                {
+                    "commit": {
+                        "statusCheckRollup": {"state": "SUCCESS"},
+                    }
+                }
+            ]
+        }
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.ci_status == CIStatus.GREEN
+
+    def test_ci_status_red(self):
+        """Test CI status detection for failing checks."""
+        pr_data = self._make_pr_data()
+        pr_data["commits"] = {
+            "nodes": [
+                {
+                    "commit": {
+                        "statusCheckRollup": {"state": "FAILURE"},
+                    }
+                }
+            ]
+        }
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.ci_status == CIStatus.RED
+
+    def test_ci_status_conflict(self):
+        """Test CI status detection for merge conflicts."""
+        pr_data = self._make_pr_data()
+        pr_data["mergeable"] = "CONFLICTING"
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.ci_status == CIStatus.CONFLICT
+
+
+class TestReviewListResult:
+    """Tests for ReviewListResult dataclass."""
+
+    def test_action_count(self):
+        """Test that action_count tracks actionable PRs."""
+        from src.review.github_api import ReviewListResult
+        from src.review.models import ReviewInfo
+
+        now = datetime.now(UTC)
+        reviews = [
+            ReviewInfo("r", 1, "t", "h", ReviewStatus.REVIEW, 0, CIStatus.GREEN, 0, "a", now),
+            ReviewInfo("r", 2, "t", "h", ReviewStatus.RE_REVIEW, 0, CIStatus.GREEN, 0, "a", now),
+            ReviewInfo("r", 3, "t", "h", ReviewStatus.HOLD, 0, CIStatus.GREEN, 0, "a", now),
+            ReviewInfo("r", 4, "t", "h", ReviewStatus.APPROVED, 0, CIStatus.GREEN, 0, "a", now),
+        ]
+
+        result = ReviewListResult(
+            reviews=reviews,
+            total_count=4,
+            has_more=False,
+            action_count=2,  # REVIEW and RE_REVIEW
+        )
+
+        assert result.action_count == 2
+        assert result.total_count == 4

--- a/tests/review/test_github_api.py
+++ b/tests/review/test_github_api.py
@@ -269,6 +269,72 @@ class TestProcessPrForReviewer:
         assert review_info is not None
         assert review_info.ci_status == CIStatus.CONFLICT
 
+    def test_merged_pr_status(self):
+        """Test that merged PRs get ReviewStatus.MERGED."""
+        pr_data = self._make_pr_data()
+        pr_data["state"] = "MERGED"
+        pr_data["closedAt"] = "2024-01-15T00:00:00Z"
+        pr_data["timelineItems"] = {
+            "nodes": [
+                {
+                    "__typename": "MergedEvent",
+                    "actor": {"login": "alice"},
+                    "createdAt": "2024-01-15T00:00:00Z",
+                },
+            ]
+        }
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.status == ReviewStatus.MERGED
+
+    def test_closed_pr_status(self):
+        """Test that closed (unmerged) PRs get ReviewStatus.CLOSED."""
+        pr_data = self._make_pr_data()
+        pr_data["state"] = "CLOSED"
+        pr_data["closedAt"] = "2024-01-15T00:00:00Z"
+        pr_data["timelineItems"] = {
+            "nodes": [
+                {
+                    "__typename": "ClosedEvent",
+                    "actor": {"login": "alice"},
+                    "createdAt": "2024-01-15T00:00:00Z",
+                },
+            ]
+        }
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.status == ReviewStatus.CLOSED
+
+    def test_merged_pr_not_marked_needs_action(self):
+        """Test that merged PRs don't need action."""
+        pr_data = self._make_pr_data()
+        pr_data["state"] = "MERGED"
+        pr_data["closedAt"] = "2024-01-15T00:00:00Z"
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.needs_action is False
+
+    def test_closed_pr_not_marked_needs_action(self):
+        """Test that closed PRs don't need action."""
+        pr_data = self._make_pr_data()
+        pr_data["state"] = "CLOSED"
+        pr_data["closedAt"] = "2024-01-15T00:00:00Z"
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob")
+
+        assert review_info is not None
+        assert review_info.needs_action is False
+
 
 class TestReviewListResult:
     """Tests for ReviewListResult dataclass."""

--- a/tests/review/test_github_api.py
+++ b/tests/review/test_github_api.py
@@ -77,6 +77,55 @@ class TestProcessPrForReviewer:
 
         assert review_info is None
 
+    def test_exclude_authors_filters_out_specified_authors(self):
+        """Test that exclude_authors filters out specified authors."""
+        pr_data = self._make_pr_data(author="dependabot[bot]")
+
+        client = ReviewClient.__new__(ReviewClient)
+        exclude_set = {"dependabot[bot]"}
+        review_info = client._process_pr_for_reviewer(pr_data, "bob", exclude_set)
+
+        assert review_info is None
+
+    def test_exclude_authors_case_insensitive(self):
+        """Test that exclude_authors matching is case-insensitive."""
+        pr_data = self._make_pr_data(author="Dependabot[bot]")
+
+        client = ReviewClient.__new__(ReviewClient)
+        exclude_set = {"dependabot[bot]"}  # lowercase
+        review_info = client._process_pr_for_reviewer(pr_data, "bob", exclude_set)
+
+        assert review_info is None
+
+    def test_exclude_authors_allows_non_matching_authors(self):
+        """Test that exclude_authors doesn't filter out other authors."""
+        pr_data = self._make_pr_data(author="alice")
+
+        client = ReviewClient.__new__(ReviewClient)
+        exclude_set = {"dependabot[bot]", "renovate[bot]"}
+        review_info = client._process_pr_for_reviewer(pr_data, "bob", exclude_set)
+
+        assert review_info is not None
+        assert review_info.author == "alice"
+
+    def test_exclude_authors_empty_set(self):
+        """Test that empty exclude_authors doesn't filter anything."""
+        pr_data = self._make_pr_data(author="alice")
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob", set())
+
+        assert review_info is not None
+
+    def test_exclude_authors_none(self):
+        """Test that None exclude_authors doesn't filter anything."""
+        pr_data = self._make_pr_data(author="alice")
+
+        client = ReviewClient.__new__(ReviewClient)
+        review_info = client._process_pr_for_reviewer(pr_data, "bob", None)
+
+        assert review_info is not None
+
     def test_re_review_status(self):
         """Test PR that needs re-review after fixes."""
         pr_data = self._make_pr_data(

--- a/tests/review/test_status.py
+++ b/tests/review/test_status.py
@@ -70,6 +70,19 @@ class TestComputeReviewStatus:
         assert status == ReviewStatus.APPROVED
         assert wait_start == approve_time
 
+    def test_re_review_after_approval(self):
+        """Test that new commits after approval trigger re-review."""
+        final_commit_time = datetime(2024, 1, 4, tzinfo=UTC)
+        events = [
+            TimelineEvent(ActionType.OPENED, "alice", datetime(2024, 1, 1, tzinfo=UTC)),
+            TimelineEvent(ActionType.HELP, "alice", datetime(2024, 1, 1, 10, tzinfo=UTC)),
+            TimelineEvent(ActionType.APPROVED, "bob", datetime(2024, 1, 2, tzinfo=UTC)),
+            TimelineEvent(ActionType.FIX, "alice", final_commit_time),
+        ]
+        status, wait_start = compute_review_status(events, "bob")
+        assert status == ReviewStatus.RE_REVIEW
+        assert wait_start == final_commit_time
+
     def test_multiple_review_cycles(self):
         """Test status after multiple review-fix cycles."""
         final_commit_time = datetime(2024, 1, 5, tzinfo=UTC)

--- a/tests/review/test_status.py
+++ b/tests/review/test_status.py
@@ -1,0 +1,215 @@
+"""Tests for review status computation."""
+
+from datetime import UTC, datetime
+
+from src.pr.models import ActionType, TimelineEvent
+from src.review.models import ReviewInfo, ReviewStatus
+from src.review.status import compute_review_status
+
+
+class TestComputeReviewStatus:
+    """Tests for compute_review_status function."""
+
+    def test_initial_review_needed_with_request(self):
+        """Test status when review is requested but not yet given."""
+        request_time = datetime(2024, 1, 2, tzinfo=UTC)
+        events = [
+            TimelineEvent(ActionType.OPENED, "alice", datetime(2024, 1, 1, tzinfo=UTC)),
+            TimelineEvent(ActionType.HELP, "alice", request_time),
+        ]
+        status, wait_start = compute_review_status(events, "bob")
+        assert status == ReviewStatus.REVIEW
+        assert wait_start == request_time
+
+    def test_initial_review_needed_no_request(self):
+        """Test fallback to PR creation time when no explicit request."""
+        open_time = datetime(2024, 1, 1, tzinfo=UTC)
+        events = [
+            TimelineEvent(ActionType.OPENED, "alice", open_time),
+        ]
+        status, wait_start = compute_review_status(events, "bob")
+        assert status == ReviewStatus.REVIEW
+        assert wait_start == open_time
+
+    def test_re_review_after_changes(self):
+        """Test re-review status when commits pushed after review."""
+        commit_time = datetime(2024, 1, 3, tzinfo=UTC)
+        events = [
+            TimelineEvent(ActionType.OPENED, "alice", datetime(2024, 1, 1, tzinfo=UTC)),
+            TimelineEvent(ActionType.HELP, "alice", datetime(2024, 1, 1, 10, tzinfo=UTC)),
+            TimelineEvent(ActionType.REVIEW, "bob", datetime(2024, 1, 2, tzinfo=UTC)),
+            TimelineEvent(ActionType.FIX, "alice", commit_time),
+        ]
+        status, wait_start = compute_review_status(events, "bob")
+        assert status == ReviewStatus.RE_REVIEW
+        assert wait_start == commit_time
+
+    def test_hold_after_changes_requested(self):
+        """Test hold status when reviewer requested changes, no new commits."""
+        review_time = datetime(2024, 1, 2, tzinfo=UTC)
+        events = [
+            TimelineEvent(ActionType.OPENED, "alice", datetime(2024, 1, 1, tzinfo=UTC)),
+            TimelineEvent(ActionType.HELP, "alice", datetime(2024, 1, 1, 10, tzinfo=UTC)),
+            TimelineEvent(ActionType.REVIEW, "bob", review_time),
+        ]
+        status, wait_start = compute_review_status(events, "bob")
+        assert status == ReviewStatus.HOLD
+        assert wait_start == review_time
+
+    def test_approved_status(self):
+        """Test approved status after reviewer approves."""
+        approve_time = datetime(2024, 1, 3, tzinfo=UTC)
+        events = [
+            TimelineEvent(ActionType.OPENED, "alice", datetime(2024, 1, 1, tzinfo=UTC)),
+            TimelineEvent(ActionType.HELP, "alice", datetime(2024, 1, 1, 10, tzinfo=UTC)),
+            TimelineEvent(ActionType.REVIEW, "bob", datetime(2024, 1, 2, tzinfo=UTC)),
+            TimelineEvent(ActionType.FIX, "alice", datetime(2024, 1, 2, 12, tzinfo=UTC)),
+            TimelineEvent(ActionType.APPROVED, "bob", approve_time),
+        ]
+        status, wait_start = compute_review_status(events, "bob")
+        assert status == ReviewStatus.APPROVED
+        assert wait_start == approve_time
+
+    def test_multiple_review_cycles(self):
+        """Test status after multiple review-fix cycles."""
+        final_commit_time = datetime(2024, 1, 5, tzinfo=UTC)
+        events = [
+            TimelineEvent(ActionType.OPENED, "alice", datetime(2024, 1, 1, tzinfo=UTC)),
+            TimelineEvent(ActionType.HELP, "alice", datetime(2024, 1, 1, 10, tzinfo=UTC)),
+            TimelineEvent(ActionType.REVIEW, "bob", datetime(2024, 1, 2, tzinfo=UTC)),
+            TimelineEvent(ActionType.FIX, "alice", datetime(2024, 1, 3, tzinfo=UTC)),
+            TimelineEvent(ActionType.REVIEW, "bob", datetime(2024, 1, 4, tzinfo=UTC)),
+            TimelineEvent(ActionType.FIX, "alice", final_commit_time),
+        ]
+        status, wait_start = compute_review_status(events, "bob")
+        assert status == ReviewStatus.RE_REVIEW
+        assert wait_start == final_commit_time
+
+    def test_case_insensitive_reviewer_matching(self):
+        """Test that reviewer matching is case-insensitive."""
+        approve_time = datetime(2024, 1, 2, tzinfo=UTC)
+        events = [
+            TimelineEvent(ActionType.OPENED, "alice", datetime(2024, 1, 1, tzinfo=UTC)),
+            TimelineEvent(ActionType.APPROVED, "Bob", approve_time),  # Uppercase
+        ]
+        status, wait_start = compute_review_status(events, "bob")  # lowercase
+        assert status == ReviewStatus.APPROVED
+        assert wait_start == approve_time
+
+    def test_other_reviewer_actions_ignored(self):
+        """Test that other reviewers' actions don't affect status."""
+        events = [
+            TimelineEvent(ActionType.OPENED, "alice", datetime(2024, 1, 1, tzinfo=UTC)),
+            TimelineEvent(ActionType.HELP, "alice", datetime(2024, 1, 1, 10, tzinfo=UTC)),
+            TimelineEvent(ActionType.APPROVED, "charlie", datetime(2024, 1, 2, tzinfo=UTC)),
+        ]
+        status, wait_start = compute_review_status(events, "bob")
+        # Bob hasn't reviewed yet, so still needs initial review
+        assert status == ReviewStatus.REVIEW
+
+    def test_multiple_request_events(self):
+        """Test using most recent request event when multiple exist."""
+        second_request_time = datetime(2024, 1, 3, tzinfo=UTC)
+        events = [
+            TimelineEvent(ActionType.OPENED, "alice", datetime(2024, 1, 1, tzinfo=UTC)),
+            TimelineEvent(ActionType.HELP, "alice", datetime(2024, 1, 2, tzinfo=UTC)),
+            TimelineEvent(ActionType.HELP, "alice", second_request_time),
+        ]
+        status, wait_start = compute_review_status(events, "bob")
+        assert status == ReviewStatus.REVIEW
+        assert wait_start == second_request_time
+
+    def test_empty_timeline(self):
+        """Test handling of empty timeline (edge case)."""
+        status, wait_start = compute_review_status([], "bob")
+        assert status == ReviewStatus.REVIEW
+        # wait_start should be approximately now
+
+
+class TestReviewInfo:
+    """Tests for ReviewInfo dataclass."""
+
+    def test_needs_action_review(self):
+        """Test needs_action is True for REVIEW status."""
+        info = ReviewInfo(
+            repo="owner/repo",
+            number=1,
+            title="Test PR",
+            history="OH",
+            status=ReviewStatus.REVIEW,
+            wait_seconds=3600.0,
+            ci_status=None,  # type: ignore
+            unresolved_thread_count=0,
+            author="alice",
+            last_activity=datetime.now(UTC),
+        )
+        assert info.needs_action is True
+
+    def test_needs_action_re_review(self):
+        """Test needs_action is True for RE_REVIEW status."""
+        info = ReviewInfo(
+            repo="owner/repo",
+            number=1,
+            title="Test PR",
+            history="OHrF",
+            status=ReviewStatus.RE_REVIEW,
+            wait_seconds=3600.0,
+            ci_status=None,  # type: ignore
+            unresolved_thread_count=0,
+            author="alice",
+            last_activity=datetime.now(UTC),
+        )
+        assert info.needs_action is True
+
+    def test_needs_action_hold_false(self):
+        """Test needs_action is False for HOLD status."""
+        info = ReviewInfo(
+            repo="owner/repo",
+            number=1,
+            title="Test PR",
+            history="OHr",
+            status=ReviewStatus.HOLD,
+            wait_seconds=3600.0,
+            ci_status=None,  # type: ignore
+            unresolved_thread_count=0,
+            author="alice",
+            last_activity=datetime.now(UTC),
+        )
+        assert info.needs_action is False
+
+    def test_needs_action_approved_false(self):
+        """Test needs_action is False for APPROVED status."""
+        info = ReviewInfo(
+            repo="owner/repo",
+            number=1,
+            title="Test PR",
+            history="OHa",
+            status=ReviewStatus.APPROVED,
+            wait_seconds=3600.0,
+            ci_status=None,  # type: ignore
+            unresolved_thread_count=0,
+            author="alice",
+            last_activity=datetime.now(UTC),
+        )
+        assert info.needs_action is False
+
+    def test_status_priority_ordering(self):
+        """Test that status priorities sort correctly."""
+        from src.pr.models import CIStatus
+
+        now = datetime.now(UTC)
+        infos = [
+            ReviewInfo("r", 1, "t", "h", ReviewStatus.APPROVED, 0, CIStatus.GREEN, 0, "a", now),
+            ReviewInfo("r", 2, "t", "h", ReviewStatus.REVIEW, 0, CIStatus.GREEN, 0, "a", now),
+            ReviewInfo("r", 3, "t", "h", ReviewStatus.HOLD, 0, CIStatus.GREEN, 0, "a", now),
+            ReviewInfo("r", 4, "t", "h", ReviewStatus.RE_REVIEW, 0, CIStatus.GREEN, 0, "a", now),
+        ]
+
+        # Sort by status_priority
+        sorted_infos = sorted(infos, key=lambda x: x.status_priority)
+
+        # Expected order: REVIEW, RE_REVIEW, HOLD, APPROVED
+        assert sorted_infos[0].status == ReviewStatus.REVIEW
+        assert sorted_infos[1].status == ReviewStatus.RE_REVIEW
+        assert sorted_infos[2].status == ReviewStatus.HOLD
+        assert sorted_infos[3].status == ReviewStatus.APPROVED

--- a/tests/review/test_status.py
+++ b/tests/review/test_status.py
@@ -226,3 +226,56 @@ class TestReviewInfo:
         assert sorted_infos[1].status == ReviewStatus.RE_REVIEW
         assert sorted_infos[2].status == ReviewStatus.HOLD
         assert sorted_infos[3].status == ReviewStatus.APPROVED
+
+    def test_needs_action_merged_false(self):
+        """Test needs_action is False for MERGED status."""
+        info = ReviewInfo(
+            repo="owner/repo",
+            number=1,
+            title="Test PR",
+            history="OHaM",
+            status=ReviewStatus.MERGED,
+            wait_seconds=3600.0,
+            ci_status=None,  # type: ignore
+            unresolved_thread_count=0,
+            author="alice",
+            last_activity=datetime.now(UTC),
+        )
+        assert info.needs_action is False
+
+    def test_needs_action_closed_false(self):
+        """Test needs_action is False for CLOSED status."""
+        info = ReviewInfo(
+            repo="owner/repo",
+            number=1,
+            title="Test PR",
+            history="OHC",
+            status=ReviewStatus.CLOSED,
+            wait_seconds=3600.0,
+            ci_status=None,  # type: ignore
+            unresolved_thread_count=0,
+            author="alice",
+            last_activity=datetime.now(UTC),
+        )
+        assert info.needs_action is False
+
+    def test_status_priority_includes_merged_closed(self):
+        """Test that MERGED and CLOSED have lower priority than open statuses."""
+        from src.pr.models import CIStatus
+
+        now = datetime.now(UTC)
+        infos = [
+            ReviewInfo("r", 1, "t", "h", ReviewStatus.MERGED, 0, CIStatus.GREEN, 0, "a", now),
+            ReviewInfo("r", 2, "t", "h", ReviewStatus.REVIEW, 0, CIStatus.GREEN, 0, "a", now),
+            ReviewInfo("r", 3, "t", "h", ReviewStatus.CLOSED, 0, CIStatus.GREEN, 0, "a", now),
+            ReviewInfo("r", 4, "t", "h", ReviewStatus.APPROVED, 0, CIStatus.GREEN, 0, "a", now),
+        ]
+
+        # Sort by status_priority
+        sorted_infos = sorted(infos, key=lambda x: x.status_priority)
+
+        # MERGED and CLOSED should be at the end (lower priority = later)
+        assert sorted_infos[0].status == ReviewStatus.REVIEW
+        assert sorted_infos[1].status == ReviewStatus.APPROVED
+        assert sorted_infos[2].status == ReviewStatus.MERGED
+        assert sorted_infos[3].status == ReviewStatus.CLOSED


### PR DESCRIPTION
## Summary

Adds design document for a new `lxa review` command that provides a reviewer-centric view of your GitHub review queue.

Closes #76

## Design Highlights

### Core Concept
While `lxa pr list` answers "What's happening with my PRs?", `lxa review` answers "What PRs need my review attention?"

### Key Features
- **Default view**: Only PRs needing your action (pending review or re-review)
- **History string**: Reuses the signature feature, showing timeline from reviewer perspective
- **Status column**: `review`, `re-review`, `hold`, `approved`
- **Wait time**: How long the PR has been waiting specifically for you
- **Priority sorting**: Longest-waiting reviews surface first

### Example Output
```
 Repo           PR    History   Status      Wait    CI       💬   Author   Last
─────────────────────────────────────────────────────────────────────────────────
 owner/repo    #142   OHrF      re-review   3h      green     2   alice    1h ago
 owner/repo2   #51    OH        review      2d      green    --   bob      2h ago
```

## Implementation Plan

The design doc outlines 4 milestones:
1. Core data model and status computation logic
2. GitHub API integration
3. CLI command implementation
4. Polish and documentation

## Files Changed

- `.pr/review-command-design.md` - Full design document

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*