### PR TITLE
feat: add `lxa issue` command for issue history visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,90 @@ The table shows:
 - **CI**: Build status (green/red/pending/conflict)
 - **💬**: Count of unresolved review threads
 
+### Issue History
+
+View your GitHub issues with compact history codes showing activity timeline. While `lxa pr list` answers "What's happening with my PRs?", `lxa issue list` answers "What's happening with my issues?"
+
+```bash
+# List issues I created (default)
+lxa issue list
+
+# Filter by state
+lxa issue list --open        # or -O (default)
+lxa issue list --closed      # or -C
+lxa issue list --all         # or -A
+
+# Filter by author
+lxa issue list --author me   # default
+lxa issue list --author octocat
+
+# Filter by repo or board
+lxa issue list --repo owner/repo
+lxa issue list --board my-project
+
+# Filter by label (supports AND/OR semantics)
+lxa issue list --label bug                    # has "bug" label
+lxa issue list --label bug --label urgent     # has BOTH (AND)
+lxa issue list --label bug,stale              # has EITHER (OR)
+lxa issue list --label bug,stale --label P1   # (bug OR stale) AND P1
+
+# Show issue titles
+lxa issue list --title       # or -t
+
+# Sort by recent activity instead of creation date
+lxa issue list --activity    # or -s
+
+# Limit results
+lxa issue list --limit 50    # or -n 50
+
+# View specific issues (by ref or URL)
+lxa issue list owner/repo#123 owner/repo#456
+lxa issue list https://github.com/owner/repo/issues/123
+
+# Pipe issue URLs from stdin
+cat issue-urls.txt | lxa issue list
+echo "https://github.com/owner/repo/issues/123" | lxa issue list --title
+```
+
+The table shows:
+- **Repo**: Repository name
+- **Issue**: Issue number
+- **History**: Compact activity timeline (see below)
+- **PR**: Linked implementing PR (if any)
+- **Labels**: Comma-separated list of labels
+- **State**: `open` or `closed`
+- **Age**: Time since issue was opened
+- **Last**: Time since last activity
+
+**History String Characters:**
+
+| Char | Meaning |
+|------|---------|
+| `o` | Issue opened |
+| `c/C` | Comment (lowercase=you, uppercase=others) |
+| `B` | Bot comment (always uppercase) |
+| `l/L` | Label added |
+| `a` | Assigned |
+| `x` | Closed |
+| `r` | Reopened |
+| `p` | PR linked |
+
+**Example output:**
+```
+Repo              Issue   History     PR       Labels              State    Age      Last
+owner/repo        #123    oCLxr       #456     bug,help wanted     open     15d      2d ago
+owner/repo        #124    olc         --       enhancement         open     3d       1h ago
+other/repo        #42     oClLCBx     #78      bug,stale           closed   45d      10d ago
+```
+
+**Bot Detection:**
+
+Bot comments are marked with `B` in the history string. Bots are detected by:
+1. Username ending with `[bot]` (e.g., `dependabot[bot]`)
+2. Configurable list in `~/.lxa/config.toml` under `[issue]` section
+
+Default recognized bots include: `github-actions[bot]`, `stale[bot]`, `dependabot[bot]`, `renovate[bot]`, and others.
+
 ### Repository Management
 
 Manage watched repositories across boards:
@@ -447,6 +531,7 @@ make test-cov
 | [Implementation Agent](doc/design/implementation-agent-design.md) | Orchestrator and Task Agent architecture |
 | [Design Composition Agent](doc/design/design-composition-agent.md) | Agent for composing design documents |
 | [Markdown Tool](doc/design/markdown-tool.md) | Structural editing tool for markdown |
+| [Issue Command](doc/design/issue-command-proposal.md) | Issue history visualization command |
 
 ### Reference
 

--- a/doc/design/issue-command-proposal.md
+++ b/doc/design/issue-command-proposal.md
@@ -1,0 +1,577 @@
+# Issue Command Proposal
+
+## Overview
+
+Add an `lxa issue` command that provides visibility into GitHub issues with a history string similar to the PR command. This answers the question: "What's happening with my issues?"
+
+## User Experience
+
+### Command Structure
+
+```bash
+# List issues I created (default)
+lxa issue list
+
+# Filter by state
+lxa issue list --open        # or -O (default)
+lxa issue list --closed      # or -C
+lxa issue list --all         # or -A
+
+# Filter by author
+lxa issue list --author me   # default
+lxa issue list --author octocat
+
+# Filter by repo or board
+lxa issue list --repo owner/repo
+lxa issue list --board my-project
+
+# Filter by label (see "Label Filtering" section below for details)
+lxa issue list --label bug
+lxa issue list --label bug --label urgent         # AND
+lxa issue list --label bug,stale                  # OR
+
+# Show titles
+lxa issue list --title       # or -t
+
+# Sort by recent activity instead of creation date
+lxa issue list --activity    # or -s
+
+# Limit results
+lxa issue list --limit 50    # or -n 50
+
+# View specific issues
+lxa issue list owner/repo#123 owner/repo#456
+```
+
+### Display Format
+
+```
+Repo              Issue   History     PR       Labels              State    Age      Last
+owner/repo        #123    oCLxr       #456     bug,help wanted     open     15d      2d ago
+owner/repo        #124    olc         --       enhancement         open     3d       1h ago
+other/repo        #42     oClLCx      #78      bug,stale           closed   45d      10d ago
+```
+
+**Columns:**
+- **Repo**: Repository name
+- **Issue**: Issue number
+- **History**: Compact activity timeline (see below)
+- **PR**: Linked implementing PR (if any), or `--` if none
+- **Labels**: Comma-separated list of labels (alphabetically sorted), or `--` if none
+- **State**: `open` or `closed`
+- **Age**: Time since issue was opened
+- **Last**: Time since last activity
+
+### History String
+
+The history string encodes the issue's lifecycle. Like PRs, **lowercase = reference user, UPPERCASE = others**, with a special marker for bot actions:
+
+| Character | Meaning |
+|-----------|---------|
+| `o` | Issue opened |
+| `c` | Comment (by reference user) |
+| `C` | Comment (by other human) |
+| `B` | Comment (by bot) |
+| `l` | Label added (by reference user) |
+| `L` | Label added (by other human or bot) |
+| `a` | Assigned |
+| `x` | Closed |
+| `r` | Reopened |
+| `p` | Linked to PR (reference detected) |
+
+**Bot Detection:**
+- Bot **comments** get the special `B` marker to distinguish from human comments
+- Bot **labels** use `L` (same as other humans) - labels are typically less noisy than comments
+- This keeps the history string readable while highlighting bot comment activity
+
+**Examples:**
+- `oCLx` - Opened, got a comment (other), labeled, then closed
+- `oclBLx` - Opened, self-commented, labeled by self, bot commented (B), bot labeled, closed
+- `oCpx` - Opened, got a comment, linked to PR, closed
+- `oClCBx` - Opened, commented, labeled, commented (other), bot commented, closed
+
+### Label Filtering
+
+The `--label` flag supports both AND and OR filtering:
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  REPEATING the flag = AND (must have ALL labels)                        │
+│  COMMA-SEPARATED    = OR  (must have ANY of the labels)                 │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Examples:**
+
+| Command | Meaning |
+|---------|---------|
+| `--label bug` | Has the "bug" label |
+| `--label bug --label urgent` | Has BOTH "bug" AND "urgent" |
+| `--label bug,stale` | Has EITHER "bug" OR "stale" |
+| `--label bug,stale --label P1` | Has ("bug" OR "stale") AND "P1" |
+
+**Why this convention?**
+- Repeating a flag accumulates requirements → AND
+- Comma-separated values are alternatives → OR
+- This matches intuition from other CLI tools
+
+**Quoting labels with spaces:**
+```bash
+lxa issue list --label "help wanted"
+lxa issue list --label "help wanted","good first issue"   # OR
+lxa issue list --label "help wanted" --label bug          # AND
+```
+
+### Sorting
+
+**Default:** Newest issues first (by `created_at` descending)
+
+**With `--activity` flag:** Most recently active first (by `last_activity` descending)
+
+This matches user expectations:
+- Default shows "what issues have I created recently"
+- Activity sort shows "what's been happening on my issues"
+
+## Data Model
+
+### IssueInfo
+
+```python
+@dataclass
+class IssueInfo:
+    repo: str
+    number: int
+    title: str
+    state: IssueState  # OPEN, CLOSED
+    history: str  # Compact history string
+    linked_pr: str | None  # "owner/repo#123" or None
+    labels: list[str]  # Alphabetically sorted labels
+    created_at: datetime
+    closed_at: datetime | None
+    last_activity: datetime
+    author: str
+    
+    @property
+    def age_seconds(self) -> float:
+        """Time from open to close (or now if open)."""
+        
+    @property
+    def last_activity_seconds(self) -> float:
+        """Time since last activity."""
+    
+    @property
+    def labels_display(self) -> str:
+        """Comma-separated labels for display."""
+        return ",".join(self.labels) if self.labels else "--"
+```
+
+### IssueActionType
+
+```python
+class IssueActionType(Enum):
+    OPENED = "o"
+    COMMENT = "c"
+    BOT_COMMENT = "B"  # Special: always uppercase
+    LABELED = "l"
+    ASSIGNED = "a"
+    CLOSED = "x"
+    REOPENED = "r"
+    PR_LINKED = "p"
+```
+
+## Configuration
+
+### Bot Username Configuration
+
+Bot detection uses a configurable list of usernames. Store in `~/.lxa/config.toml`:
+
+```toml
+[issue]
+bot_usernames = [
+    "github-actions[bot]",
+    "stale[bot]", 
+    "dependabot[bot]",
+    "renovate[bot]",
+    "allcontributors[bot]",
+    "codecov[bot]",
+    "sonarcloud[bot]"
+]
+```
+
+**Default bots** (hardcoded, extend with config):
+- `*[bot]` - Any username ending in `[bot]`
+- `github-actions` - GitHub Actions
+- `stale` - GitHub stale action
+
+**CLI for managing:**
+```bash
+# View current bot list
+lxa issue config bots
+
+# Add a bot
+lxa issue config bots add my-custom-bot
+
+# Remove a bot  
+lxa issue config bots remove my-custom-bot
+
+# Reset to defaults
+lxa issue config bots reset
+```
+
+## GitHub API Integration
+
+### GraphQL Query
+
+```graphql
+fragment IssueFields on Issue {
+    number
+    title
+    state
+    createdAt
+    closedAt
+    author { login }
+    repository { nameWithOwner }
+    labels(first: 20) {
+        nodes { name }
+    }
+    
+    # Get linked PRs via cross-references
+    timelineItems(first: 100, itemTypes: [
+        ISSUE_COMMENT,
+        LABELED_EVENT,
+        UNLABELED_EVENT,
+        CLOSED_EVENT,
+        REOPENED_EVENT,
+        ASSIGNED_EVENT,
+        CROSS_REFERENCED_EVENT
+    ]) {
+        nodes {
+            __typename
+            ... on IssueComment {
+                author { login }
+                createdAt
+            }
+            ... on LabeledEvent {
+                actor { login }
+                label { name }
+                createdAt
+            }
+            ... on UnlabeledEvent {
+                actor { login }
+                label { name }
+                createdAt
+            }
+            ... on ClosedEvent {
+                actor { login }
+                createdAt
+            }
+            ... on ReopenedEvent {
+                actor { login }
+                createdAt
+            }
+            ... on AssignedEvent {
+                actor { login }
+                assignee { login }
+                createdAt
+            }
+            ... on CrossReferencedEvent {
+                source {
+                    ... on PullRequest {
+                        number
+                        repository { nameWithOwner }
+                        state
+                    }
+                }
+                actor { login }
+                createdAt
+            }
+        }
+    }
+}
+```
+
+### Search Query Building
+
+```python
+def build_search_query(
+    author: str | None,
+    repos: list[str] | None,
+    states: list[str] | None,
+    labels: list[str] | None,
+) -> str:
+    """Build GitHub search query for issues.
+    
+    Label filtering:
+    - Multiple --label flags = AND (must have all)
+    - Comma-separated in single flag = OR (has any)
+    
+    GitHub API only supports AND natively, so OR requires special handling.
+    """
+    parts = ["is:issue"]
+    
+    if author:
+        parts.append(f"author:{author}")
+    
+    if repos:
+        for repo in repos:
+            parts.append(f"repo:{repo}")
+    
+    if states:
+        # Similar to PR state handling
+        if "open" in states and "closed" not in states:
+            parts.append("is:open")
+        elif "closed" in states and "open" not in states:
+            parts.append("is:closed")
+    
+    if labels:
+        # Each label arg is AND'd together
+        # Comma-separated values within an arg are OR'd (handled separately)
+        for label_arg in labels:
+            if "," not in label_arg:
+                # Simple label - add directly to query (AND)
+                if " " in label_arg:
+                    parts.append(f'label:"{label_arg}"')
+                else:
+                    parts.append(f"label:{label_arg}")
+            # Comma-separated (OR) labels handled via client-side filtering
+            # or multiple queries - see _handle_or_labels()
+    
+    return " ".join(parts)
+
+
+def parse_label_filters(label_args: list[str]) -> tuple[list[str], list[list[str]]]:
+    """Parse label arguments into AND labels and OR label groups.
+    
+    Args:
+        label_args: List of label arguments (e.g., ["bug", "stale,wontfix", "urgent"])
+    
+    Returns:
+        Tuple of (and_labels, or_groups):
+        - and_labels: Labels that must all be present
+        - or_groups: Groups where at least one label must be present
+        
+    Example:
+        parse_label_filters(["bug", "stale,wontfix", "urgent"])
+        -> (["bug", "urgent"], [["stale", "wontfix"]])
+        
+        Meaning: must have "bug" AND "urgent" AND (stale OR wontfix)
+    """
+    and_labels = []
+    or_groups = []
+    
+    for arg in label_args:
+        if "," in arg:
+            # OR group
+            or_groups.append([l.strip() for l in arg.split(",")])
+        else:
+            # AND label
+            and_labels.append(arg.strip())
+    
+    return and_labels, or_groups
+```
+
+### Finding Linked PRs
+
+PRs can link to issues in several ways:
+1. **CrossReferencedEvent** - A PR mentions the issue in its body/comments
+2. **"Closes #X" syntax** - PR will close the issue when merged
+
+For simplicity, we use CrossReferencedEvent from the timeline:
+- If a PR references this issue, it appears as a CrossReferencedEvent
+- We take the **first PR** that references the issue as the "implementing PR"
+- If multiple PRs reference it, we prefer non-closed ones
+
+```python
+def find_linked_pr(timeline_events: list) -> str | None:
+    """Find the implementing PR from timeline events."""
+    prs = []
+    for event in timeline_events:
+        if event["__typename"] == "CrossReferencedEvent":
+            source = event.get("source")
+            if source and "number" in source:
+                repo = source["repository"]["nameWithOwner"]
+                number = source["number"]
+                state = source.get("state", "OPEN")
+                prs.append((f"{repo}#{number}", state))
+    
+    # Prefer open/merged PRs over closed
+    for pr_ref, state in prs:
+        if state != "CLOSED":
+            return pr_ref
+    
+    # Fall back to first PR if all are closed
+    return prs[0][0] if prs else None
+```
+
+## File Structure
+
+```
+src/issue/
+├── __init__.py
+├── cli/
+│   ├── __init__.py
+│   └── list_cmd.py      # CLI presentation
+├── config.py            # Issue-specific config (bot names, stale labels)
+├── github_api.py        # API client
+├── history.py           # Timeline processing
+└── models.py            # Data models
+```
+
+## CLI Parser Addition
+
+Add to `src/__main__.py`:
+
+```python
+# Issue subcommand
+issue_parser = subparsers.add_parser(
+    "issue",
+    help="Issue history visualization",
+)
+issue_subparsers = issue_parser.add_subparsers(dest="issue_command", required=True)
+
+# issue list
+issue_list_parser = issue_subparsers.add_parser(
+    "list",
+    help="List issues with history visualization",
+)
+issue_list_parser.add_argument(
+    "issue_refs",
+    nargs="*",
+    metavar="OWNER/REPO#NUM",
+    help="Specific issue references",
+)
+issue_list_parser.add_argument(
+    "--author", "-a",
+    default="me",
+    help="Filter by issue author (default: me)",
+)
+issue_list_parser.add_argument(
+    "--repo",
+    dest="repos",
+    action="append",
+    help="Filter by repo",
+)
+issue_list_parser.add_argument(
+    "--board", "-b",
+    dest="board_name",
+    help="Use repos from board",
+)
+issue_list_parser.add_argument(
+    "--label", "-l",
+    dest="labels",
+    action="append",
+    metavar="LABEL",
+    help="Filter by label. Repeat for AND, use comma for OR: "
+         "-l bug -l urgent (AND), -l bug,stale (OR)",
+)
+issue_list_parser.add_argument(
+    "--open", "-O",
+    dest="include_open",
+    action="store_true",
+    help="Show open issues (default)",
+)
+issue_list_parser.add_argument(
+    "--closed", "-C",
+    dest="include_closed",
+    action="store_true",
+    help="Show closed issues",
+)
+issue_list_parser.add_argument(
+    "--all", "-A",
+    dest="all_states",
+    action="store_true",
+    help="Show all states",
+)
+issue_list_parser.add_argument(
+    "--limit", "-n",
+    type=int,
+    default=100,
+    help="Maximum issues to show",
+)
+issue_list_parser.add_argument(
+    "--title", "-t",
+    dest="show_title",
+    action="store_true",
+    help="Show issue titles",
+)
+issue_list_parser.add_argument(
+    "--activity", "-s",
+    dest="activity_sort",
+    action="store_true",
+    help="Sort by recent activity instead of creation date",
+)
+
+# issue config (for bot management)
+issue_config_parser = issue_subparsers.add_parser(
+    "config",
+    help="Configure issue command settings",
+)
+# ... bot management subcommands
+```
+
+## Implementation Phases
+
+### Phase 1: Core Functionality
+- [ ] Create `src/issue/` module structure
+- [ ] Implement models (`IssueInfo`, `IssueActionType`, `IssueState`)
+- [ ] Implement GitHub API client with GraphQL query
+- [ ] Implement history string generation
+- [ ] Implement CLI list command
+
+### Phase 2: Bot Detection
+- [ ] Add bot detection logic (username pattern matching)
+- [ ] Add config loading for bot usernames
+
+### Phase 3: Configuration
+- [ ] Add `[issue]` section to config schema
+- [ ] Implement config CLI (`lxa issue config bots`)
+- [ ] Add defaults for common bots
+
+### Phase 4: Polish
+- [ ] Add stdin support for issue refs (like PR command)
+- [ ] Add tests
+- [ ] Update README documentation
+
+## Questions / Decisions
+
+1. **Should we track unlabeled events?** 
+   - Current proposal: No, to keep history string concise
+   - Alternative: Track as `u` (unlabeled)
+
+2. **Multiple linked PRs?**
+   - Current proposal: Show first/best match
+   - Alternative: Show count like "3 PRs" or comma-separated "#1,#2"
+
+3. **Assignee changes?**
+   - Current proposal: Track first assignment only with `a`
+   - Alternative: Track all changes
+
+## Example Output
+
+```
+$ lxa issue list
+ Repo              Issue   History     PR       Labels                   State    Age      Last
+ myorg/backend     #342    oClCBLx     --       bug,stale                closed   45d      30d ago
+ myorg/backend     #341    oCp         #356     enhancement              open     12d      2d ago
+ myorg/frontend    #89     olcCap      #91      bug,help wanted          open     5d       1d ago
+ myorg/docs        #23     oc          --       documentation            open     2d       1h ago
+
+History: o=opened, c/C=comment, l/L=label, B=bot comment, a=assigned, x=closed, r=reopened, p=PR linked
+lowercase=you, UPPERCASE=others
+
+$ lxa issue list --label bug
+ Repo              Issue   History     PR       Labels                   State    Age      Last
+ myorg/backend     #342    oClCBLx     --       bug,stale                closed   45d      30d ago
+ myorg/frontend    #89     olcCap      #91      bug,help wanted          open     5d       1d ago
+
+$ lxa issue list --label stale,wontfix    # OR: issues with stale OR wontfix
+ Repo              Issue   History     PR       Labels                   State    Age      Last
+ myorg/backend     #342    oClCBLx     --       bug,stale                closed   45d      30d ago
+ myorg/old-lib     #12     oCLx        --       wontfix                  closed   90d      60d ago
+
+$ lxa issue list --activity --title
+ Repo              Issue   Title                        History    PR       Labels           State    Age      Last
+ myorg/docs        #23     Update installation guide    oc         --       documentation    open     2d       1h ago
+ myorg/frontend    #89     Fix mobile nav               olcCap     #91      bug,help wanted  open     5d       1d ago
+ myorg/backend     #341    Add caching layer            oCp        #356     enhancement      open     12d      2d ago
+```

--- a/doc/testing/issue-command-test-plan.md
+++ b/doc/testing/issue-command-test-plan.md
@@ -1,0 +1,690 @@
+# Manual Test Plan: `lxa issue` Command
+
+This document provides a comprehensive manual test plan to validate the `lxa issue list` command introduced in PR #82. The test plan covers all major features including issue listing, filtering, history visualization, and bot detection.
+
+## Prerequisites
+
+1. **Authentication**: Ensure GitHub authentication is configured:
+   ```bash
+   # Verify gh CLI authentication
+   gh auth status
+   ```
+
+2. **Installation**: Install lxa in development mode:
+   ```bash
+   make dev
+   # or
+   uv pip install -e ".[dev]"
+   ```
+
+3. **Test Data**: You'll need access to repositories with:
+   - Open and closed issues
+   - Issues with various labels
+   - Issues with linked PRs
+   - Issues with comments from humans and bots
+   - Issues created by different authors
+
+---
+
+## Test Categories
+
+### 1. Basic Functionality
+
+#### TC-1.1: Default Issue Listing
+**Description**: Verify that `lxa issue list` shows issues created by the current user.
+
+**Steps**:
+1. Run `lxa issue list`
+2. Verify the output contains a table with columns: Repo, Issue, History, PR, Labels, State, Age, Last
+3. Verify only open issues are shown (default state filter)
+4. Verify issues are from repositories accessible to you
+
+**Expected Result**: Table displays your open issues with all columns populated.
+
+---
+
+#### TC-1.2: Issue Table Format
+**Description**: Verify the table output format is correct.
+
+**Steps**:
+1. Run `lxa issue list --all`
+2. Inspect each column:
+   - **Repo**: Should show `owner/repo` format
+   - **Issue**: Should show `#number` format
+   - **History**: Should show compact character codes
+   - **PR**: Should show `#number` or `--`
+   - **Labels**: Should show comma-separated labels or `--`
+   - **State**: Should show `open` or `closed`
+   - **Age**: Should show duration (e.g., `15d`, `2h`, `45m`)
+   - **Last**: Should show relative time (e.g., `2d ago`)
+
+**Expected Result**: All columns are properly formatted and aligned.
+
+---
+
+#### TC-1.3: Legend Display
+**Description**: Verify the legend is displayed after the table.
+
+**Steps**:
+1. Run `lxa issue list`
+2. Scroll to the bottom of the output
+
+**Expected Result**: Legend shows:
+```
+History: o=opened, c/C=comment, l/L=label, B=bot, a=assigned, x=closed, r=reopened, p=PR linked
+lowercase=you, UPPERCASE=others
+```
+
+---
+
+### 2. State Filtering
+
+#### TC-2.1: Open Issues Only (Default)
+**Description**: Verify default shows only open issues.
+
+**Steps**:
+1. Run `lxa issue list`
+2. Check the State column
+
+**Expected Result**: All issues have `open` state.
+
+---
+
+#### TC-2.2: Closed Issues Only
+**Description**: Verify `--closed` flag shows only closed issues.
+
+**Steps**:
+1. Run `lxa issue list --closed`
+2. Check the State column
+
+**Expected Result**: All issues have `closed` state.
+
+---
+
+#### TC-2.3: All Issues
+**Description**: Verify `--all` flag shows both open and closed issues.
+
+**Steps**:
+1. Run `lxa issue list --all`
+2. Check the State column
+
+**Expected Result**: Both `open` and `closed` issues are displayed.
+
+---
+
+#### TC-2.4: Short Flags
+**Description**: Verify short flags work (-O, -C, -A).
+
+**Steps**:
+1. Run `lxa issue list -O` (open)
+2. Run `lxa issue list -C` (closed)
+3. Run `lxa issue list -A` (all)
+
+**Expected Result**: Each flag produces the same result as its long form.
+
+---
+
+### 3. Author Filtering
+
+#### TC-3.1: Current User (Default)
+**Description**: Verify default lists issues by current user.
+
+**Steps**:
+1. Run `lxa issue list`
+2. Verify all issues are authored by you
+
+**Expected Result**: Only your issues are shown.
+
+---
+
+#### TC-3.2: Specific Author
+**Description**: Verify `--author` flag filters by author.
+
+**Steps**:
+1. Run `lxa issue list --author <other-username>`
+2. Verify all issues are authored by the specified user
+
+**Expected Result**: Only issues from the specified author are shown.
+
+---
+
+#### TC-3.3: Author "me" Explicit
+**Description**: Verify `--author me` explicitly sets current user.
+
+**Steps**:
+1. Run `lxa issue list --author me`
+2. Compare output with `lxa issue list`
+
+**Expected Result**: Output is identical.
+
+---
+
+### 4. Repository Filtering
+
+#### TC-4.1: Single Repository
+**Description**: Verify `--repo` filters to a single repository.
+
+**Steps**:
+1. Run `lxa issue list --repo owner/repo --all`
+2. Check the Repo column
+
+**Expected Result**: All issues are from the specified repository.
+
+---
+
+#### TC-4.2: Multiple Repositories
+**Description**: Verify multiple `--repo` flags filter to multiple repositories.
+
+**Steps**:
+1. Run `lxa issue list --repo owner/repo1 --repo owner/repo2 --all`
+2. Check the Repo column
+
+**Expected Result**: Issues are from either specified repository.
+
+---
+
+#### TC-4.3: Board Integration
+**Description**: Verify `--board` uses repos from a board.
+
+**Steps**:
+1. Ensure a board exists with configured repos
+2. Run `lxa issue list --board <board-name>`
+
+**Expected Result**: Issues are filtered to repos in the board.
+
+---
+
+### 5. Label Filtering
+
+#### TC-5.1: Single Label
+**Description**: Verify `--label` filters by a single label.
+
+**Steps**:
+1. Run `lxa issue list --label bug --all`
+2. Check the Labels column
+
+**Expected Result**: All issues have the `bug` label.
+
+---
+
+#### TC-5.2: Multiple Labels (AND)
+**Description**: Verify multiple `--label` flags use AND logic.
+
+**Steps**:
+1. Run `lxa issue list --label bug --label urgent --all`
+2. Check the Labels column
+
+**Expected Result**: All issues have BOTH `bug` AND `urgent` labels.
+
+---
+
+#### TC-5.3: Comma-Separated Labels (OR)
+**Description**: Verify comma-separated labels use OR logic.
+
+**Steps**:
+1. Run `lxa issue list --label bug,enhancement --all`
+2. Check the Labels column
+
+**Expected Result**: All issues have EITHER `bug` OR `enhancement` (or both).
+
+---
+
+#### TC-5.4: Combined AND/OR
+**Description**: Verify combined AND/OR label filtering.
+
+**Steps**:
+1. Run `lxa issue list --label bug,stale --label P1 --all`
+2. Check the Labels column
+
+**Expected Result**: Issues have (bug OR stale) AND P1.
+
+---
+
+#### TC-5.5: Labels with Spaces
+**Description**: Verify labels with spaces work when quoted.
+
+**Steps**:
+1. Run `lxa issue list --label "help wanted" --all`
+2. Check the Labels column
+
+**Expected Result**: Issues have the "help wanted" label.
+
+---
+
+### 6. Display Options
+
+#### TC-6.1: Show Titles
+**Description**: Verify `--title` flag adds Title column.
+
+**Steps**:
+1. Run `lxa issue list --title`
+2. Check for Title column
+
+**Expected Result**: Title column is displayed between Issue and History columns.
+
+---
+
+#### TC-6.2: Title Short Flag
+**Description**: Verify `-t` short flag works.
+
+**Steps**:
+1. Run `lxa issue list -t`
+2. Compare with `lxa issue list --title`
+
+**Expected Result**: Output is identical.
+
+---
+
+#### TC-6.3: Limit Results
+**Description**: Verify `--limit` restricts number of results.
+
+**Steps**:
+1. Run `lxa issue list --all --limit 5`
+2. Count the number of issues displayed
+
+**Expected Result**: At most 5 issues are shown.
+
+---
+
+#### TC-6.4: Limit Short Flag
+**Description**: Verify `-n` short flag works.
+
+**Steps**:
+1. Run `lxa issue list --all -n 5`
+2. Compare with `lxa issue list --all --limit 5`
+
+**Expected Result**: Output is identical.
+
+---
+
+### 7. Sorting
+
+#### TC-7.1: Default Sort (Creation Date)
+**Description**: Verify default sorts by creation date (newest first).
+
+**Steps**:
+1. Run `lxa issue list --all`
+2. Check the Age column - should decrease as you go down
+
+**Expected Result**: Issues are sorted by creation date descending.
+
+---
+
+#### TC-7.2: Activity Sort
+**Description**: Verify `--activity` sorts by last activity.
+
+**Steps**:
+1. Run `lxa issue list --all --activity`
+2. Check the Last column - most recent activity should be at top
+
+**Expected Result**: Issues are sorted by last activity descending.
+
+---
+
+#### TC-7.3: Activity Short Flag
+**Description**: Verify `-s` short flag works.
+
+**Steps**:
+1. Run `lxa issue list --all -s`
+2. Compare with `lxa issue list --all --activity`
+
+**Expected Result**: Output is identical.
+
+---
+
+### 8. History String
+
+#### TC-8.1: Opened Action
+**Description**: Verify `o` appears for issue creation.
+
+**Steps**:
+1. Run `lxa issue list --all`
+2. Check History column
+
+**Expected Result**: All history strings start with `o`.
+
+---
+
+#### TC-8.2: User Comment (lowercase)
+**Description**: Verify `c` appears for your own comments.
+
+**Steps**:
+1. Find an issue where you've commented
+2. Run `lxa issue list --all`
+3. Check History for that issue
+
+**Expected Result**: History contains `c` (lowercase).
+
+---
+
+#### TC-8.3: Other Comment (uppercase)
+**Description**: Verify `C` appears for comments by others.
+
+**Steps**:
+1. Find an issue where others have commented
+2. Run `lxa issue list --all`
+3. Check History for that issue
+
+**Expected Result**: History contains `C` (uppercase).
+
+---
+
+#### TC-8.4: Bot Comment
+**Description**: Verify `B` appears for bot comments.
+
+**Steps**:
+1. Find an issue with bot comments (e.g., dependabot, stale bot)
+2. Run `lxa issue list --all`
+3. Check History for that issue
+
+**Expected Result**: History contains `B` for bot comments.
+
+---
+
+#### TC-8.5: Label Added
+**Description**: Verify `l/L` appears for label events.
+
+**Steps**:
+1. Find an issue where labels were added
+2. Run `lxa issue list --all`
+3. Check History
+
+**Expected Result**: History contains `l` (you) or `L` (others) for label events.
+
+---
+
+#### TC-8.6: Closed Issue
+**Description**: Verify `x` appears for closed issues.
+
+**Steps**:
+1. Run `lxa issue list --closed`
+2. Check History column
+
+**Expected Result**: Closed issues have `x` in their history.
+
+---
+
+#### TC-8.7: Reopened Issue
+**Description**: Verify `r` appears for reopened issues.
+
+**Steps**:
+1. Find an issue that was reopened
+2. Check History
+
+**Expected Result**: History contains `r` for reopen event.
+
+---
+
+#### TC-8.8: Linked PR
+**Description**: Verify `p` appears when a PR references the issue.
+
+**Steps**:
+1. Find an issue with a linked PR (check PR column shows a number)
+2. Check History
+
+**Expected Result**: History contains `p` for PR link event.
+
+---
+
+#### TC-8.9: Assigned
+**Description**: Verify `a` appears for assignment events.
+
+**Steps**:
+1. Find an issue that was assigned
+2. Check History
+
+**Expected Result**: History contains `a` for assignment.
+
+---
+
+### 9. Linked PR Column
+
+#### TC-9.1: No Linked PR
+**Description**: Verify `--` is shown when no PR is linked.
+
+**Steps**:
+1. Find an issue without a linked PR
+2. Check PR column
+
+**Expected Result**: PR column shows `--`.
+
+---
+
+#### TC-9.2: Linked PR Present
+**Description**: Verify PR number is shown when linked.
+
+**Steps**:
+1. Find an issue with a linked PR
+2. Check PR column
+
+**Expected Result**: PR column shows `#<number>` in green.
+
+---
+
+### 10. Input Methods
+
+#### TC-10.1: Specific Issue References
+**Description**: Verify specific issues can be queried by reference.
+
+**Steps**:
+1. Run `lxa issue list owner/repo#123`
+2. Verify the specific issue is shown
+
+**Expected Result**: Only the specified issue is displayed.
+
+---
+
+#### TC-10.2: Multiple Issue References
+**Description**: Verify multiple issues can be specified.
+
+**Steps**:
+1. Run `lxa issue list owner/repo#123 owner/repo#456`
+2. Verify both issues are shown
+
+**Expected Result**: Both specified issues are displayed.
+
+---
+
+#### TC-10.3: Issue URL Input
+**Description**: Verify GitHub URLs work as input.
+
+**Steps**:
+1. Run `lxa issue list https://github.com/owner/repo/issues/123`
+2. Verify the issue is shown
+
+**Expected Result**: Issue is displayed correctly.
+
+---
+
+#### TC-10.4: Stdin Pipe
+**Description**: Verify issues can be piped from stdin.
+
+**Steps**:
+1. Run `echo "owner/repo#123" | lxa issue list`
+2. Verify the issue is shown
+
+**Expected Result**: Issue is displayed correctly.
+
+---
+
+#### TC-10.5: Multiple Lines from Stdin
+**Description**: Verify multiple issues from stdin.
+
+**Steps**:
+1. Create a file `issues.txt` with issue refs (one per line)
+2. Run `cat issues.txt | lxa issue list`
+
+**Expected Result**: All issues from the file are displayed.
+
+---
+
+### 11. Edge Cases
+
+#### TC-11.1: No Issues Found
+**Description**: Verify appropriate message when no issues match.
+
+**Steps**:
+1. Run `lxa issue list --repo nonexistent/repo`
+2. Or run with impossible filter combination
+
+**Expected Result**: Message: "No issues found."
+
+---
+
+#### TC-11.2: Pagination Notice
+**Description**: Verify pagination notice when results are truncated.
+
+**Steps**:
+1. Run `lxa issue list --all --limit 5` (assuming > 5 issues exist)
+2. Check bottom of output
+
+**Expected Result**: Shows "Showing 5 of X issues" message.
+
+---
+
+#### TC-11.3: Empty Labels
+**Description**: Verify `--` is shown for issues without labels.
+
+**Steps**:
+1. Find an issue without labels
+2. Check Labels column
+
+**Expected Result**: Labels column shows `--`.
+
+---
+
+#### TC-11.4: Long Label Truncation
+**Description**: Verify long labels are truncated properly.
+
+**Steps**:
+1. Find an issue with many labels
+2. Check Labels column width
+
+**Expected Result**: Labels are truncated with ellipsis if too long.
+
+---
+
+### 12. Error Handling
+
+#### TC-12.1: Invalid Issue Reference
+**Description**: Verify error handling for invalid references.
+
+**Steps**:
+1. Run `lxa issue list invalid-ref`
+2. Check error output
+
+**Expected Result**: Appropriate error message is displayed.
+
+---
+
+#### TC-12.2: Inaccessible Repository
+**Description**: Verify error handling for inaccessible repos.
+
+**Steps**:
+1. Run `lxa issue list --repo private/repo` (that you can't access)
+2. Check output
+
+**Expected Result**: Error message or "No issues found."
+
+---
+
+#### TC-12.3: API Rate Limiting
+**Description**: Verify graceful handling of API rate limits.
+
+**Steps**:
+1. Make many rapid API calls to potentially hit rate limits
+2. Check error handling
+
+**Expected Result**: Clear error message about rate limiting.
+
+---
+
+### 13. Integration Tests
+
+#### TC-13.1: Combined Filters
+**Description**: Verify multiple filters work together.
+
+**Steps**:
+1. Run `lxa issue list --repo owner/repo --label bug --open --limit 10 --title`
+2. Verify all filters are applied
+
+**Expected Result**: Output respects all filter conditions.
+
+---
+
+#### TC-13.2: Board + State + Label
+**Description**: Verify board integration with other filters.
+
+**Steps**:
+1. Run `lxa issue list --board my-board --closed --label enhancement`
+2. Verify results match all criteria
+
+**Expected Result**: Issues match board repos, state, and label.
+
+---
+
+---
+
+## Test Environment Setup
+
+### Creating Test Data
+
+If you need to create test data:
+
+1. **Create test issues**:
+   ```bash
+   gh issue create --repo owner/repo --title "Test issue" --body "Test body"
+   ```
+
+2. **Add labels**:
+   ```bash
+   gh issue edit --repo owner/repo 123 --add-label "bug"
+   ```
+
+3. **Add comments**:
+   ```bash
+   gh issue comment --repo owner/repo 123 --body "Test comment"
+   ```
+
+4. **Close issues**:
+   ```bash
+   gh issue close --repo owner/repo 123
+   ```
+
+5. **Link to PR** (create a PR that mentions the issue in body/title)
+
+---
+
+## Reporting Issues
+
+If you find bugs during testing:
+
+1. Document the exact command used
+2. Capture the full output (including any error messages)
+3. Note the expected vs actual behavior
+4. Include relevant environment details (OS, Python version)
+5. Create a GitHub issue with the details
+
+---
+
+## Sign-Off Checklist
+
+| Category | Tests Passed | Notes |
+|----------|--------------|-------|
+| Basic Functionality (TC-1.x) | ☐ | |
+| State Filtering (TC-2.x) | ☐ | |
+| Author Filtering (TC-3.x) | ☐ | |
+| Repository Filtering (TC-4.x) | ☐ | |
+| Label Filtering (TC-5.x) | ☐ | |
+| Display Options (TC-6.x) | ☐ | |
+| Sorting (TC-7.x) | ☐ | |
+| History String (TC-8.x) | ☐ | |
+| Linked PR Column (TC-9.x) | ☐ | |
+| Input Methods (TC-10.x) | ☐ | |
+| Edge Cases (TC-11.x) | ☐ | |
+| Error Handling (TC-12.x) | ☐ | |
+| Integration Tests (TC-13.x) | ☐ | |
+
+**Tester**: _______________  
+**Date**: _______________  
+**Version**: _______________

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1620,6 +1620,99 @@ Configuration:
         help="Show closed (unmerged) PRs you've reviewed",
     )
 
+    # issue command - issue history visualization
+    issue_parser = subparsers.add_parser(
+        "issue",
+        help="Issue history visualization",
+    )
+    issue_subparsers = issue_parser.add_subparsers(dest="issue_command", required=True)
+
+    # issue list
+    issue_list_parser = issue_subparsers.add_parser(
+        "list",
+        help="List issues with history visualization",
+        description="List issues with history visualization. "
+        "Default shows issues created by you. "
+        "Accepts issue references as arguments (owner/repo#number).",
+    )
+    issue_list_parser.add_argument(
+        "issue_refs",
+        nargs="*",
+        metavar="OWNER/REPO#NUM",
+        help="Specific issue references (owner/repo#number)",
+    )
+    issue_list_parser.add_argument(
+        "--author",
+        "-a",
+        metavar="USER",
+        help="Filter by issue author (default: current user)",
+    )
+    issue_list_parser.add_argument(
+        "--repo",
+        dest="repos",
+        action="append",
+        metavar="OWNER/REPO",
+        help="Filter by repo (can be specified multiple times)",
+    )
+    issue_list_parser.add_argument(
+        "--board",
+        "-b",
+        dest="board_name",
+        metavar="NAME",
+        help="Use repos from specified board",
+    )
+    issue_list_parser.add_argument(
+        "--label",
+        "-l",
+        dest="labels",
+        action="append",
+        metavar="LABEL",
+        help="Filter by label. Repeat for AND, use comma for OR: "
+        "-l bug -l urgent (AND), -l bug,stale (OR)",
+    )
+    issue_list_parser.add_argument(
+        "--open",
+        "-O",
+        dest="include_open",
+        action="store_true",
+        help="Show open issues (default if no state flags given)",
+    )
+    issue_list_parser.add_argument(
+        "--closed",
+        "-C",
+        dest="include_closed",
+        action="store_true",
+        help="Show closed issues",
+    )
+    issue_list_parser.add_argument(
+        "--all",
+        "-A",
+        dest="all_states",
+        action="store_true",
+        help="Show all states (open, closed)",
+    )
+    issue_list_parser.add_argument(
+        "--limit",
+        "-n",
+        type=int,
+        default=100,
+        help="Maximum number of issues to show (default: 100)",
+    )
+    issue_list_parser.add_argument(
+        "--title",
+        "-t",
+        dest="show_title",
+        action="store_true",
+        help="Show issue titles",
+    )
+    issue_list_parser.add_argument(
+        "--activity",
+        "-s",
+        dest="sort_by_activity",
+        action="store_true",
+        help="Sort by recent activity instead of creation date",
+    )
+
     # repo command
     repo_parser = subparsers.add_parser(
         "repo",
@@ -1868,6 +1961,40 @@ Configuration:
             show_title=args.show_title,
             states=review_states,
         )
+
+    # Handle issue command
+    if args.command == "issue":
+        from src.issue.cli import cmd_list as issue_cmd_list
+
+        if args.issue_command == "list":
+            # Build states list based on flags
+            issue_states: list[str] | None = None
+            if args.all_states:
+                issue_states = ["open", "closed"]
+            elif args.include_open or args.include_closed:
+                issue_states = []
+                if args.include_open:
+                    issue_states.append("open")
+                if args.include_closed:
+                    issue_states.append("closed")
+            # Default: open only (handled by None -> defaults in cmd_list)
+
+            # Read from stdin if no refs provided and stdin has data
+            issue_refs = args.issue_refs
+            if not issue_refs and not sys.stdin.isatty():
+                issue_refs = _read_issue_refs_from_stdin()
+
+            return issue_cmd_list(
+                author=args.author,
+                repos=args.repos,
+                issue_refs=issue_refs if issue_refs else None,
+                states=issue_states,
+                labels=args.labels,
+                board_name=args.board_name,
+                limit=args.limit,
+                show_title=args.show_title,
+                sort_by_activity=args.sort_by_activity,
+            )
 
     # Handle repo command
     if args.command == "repo":
@@ -2173,6 +2300,40 @@ def _read_pr_refs_from_stdin() -> list[str]:
                 repo_slug, pr_number = parse_pr_url(line)
                 refs.append(f"{repo_slug}#{pr_number}")
             except ValueError:
+                console.print(f"[yellow]Warning: Skipping invalid URL: {line}[/]")
+        else:
+            # Assume it's already in owner/repo#number format
+            refs.append(line)
+
+    return refs
+
+
+def _read_issue_refs_from_stdin() -> list[str]:
+    """Read issue references from stdin, converting URLs to owner/repo#number format.
+
+    Accepts both formats:
+    - GitHub issue URLs: https://github.com/owner/repo/issues/123
+    - Direct refs: owner/repo#123
+
+    Returns:
+        List of issue references in owner/repo#number format
+    """
+    import re
+
+    refs = []
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+
+        # Check if it's a GitHub issue URL
+        if line.startswith("https://github.com/"):
+            match = re.match(r"https://github\.com/([^/]+/[^/]+)/issues/(\d+)", line)
+            if match:
+                repo_slug = match.group(1)
+                issue_number = match.group(2)
+                refs.append(f"{repo_slug}#{issue_number}")
+            else:
                 console.print(f"[yellow]Warning: Skipping invalid URL: {line}[/]")
         else:
             # Assume it's already in owner/repo#number format

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -2278,61 +2278,36 @@ def find_git_root(start_path: Path) -> Path:
     return start_path
 
 
-def _read_pr_refs_from_stdin() -> list[str]:
-    """Read PR references from stdin, converting URLs to owner/repo#number format.
+def _read_refs_from_stdin(item_type: str) -> list[str]:
+    """Read GitHub refs from stdin, converting URLs to owner/repo#number format.
+
+    Args:
+        item_type: 'pull' for PRs or 'issues' for issues (used in URL pattern matching)
 
     Accepts both formats:
-    - GitHub PR URLs: https://github.com/owner/repo/pull/123
+    - GitHub URLs: https://github.com/owner/repo/{item_type}/123
     - Direct refs: owner/repo#123
 
     Returns:
-        List of PR references in owner/repo#number format
-    """
-    refs = []
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
-            continue
-
-        # Check if it's a GitHub PR URL
-        if line.startswith("https://github.com/"):
-            try:
-                repo_slug, pr_number = parse_pr_url(line)
-                refs.append(f"{repo_slug}#{pr_number}")
-            except ValueError:
-                console.print(f"[yellow]Warning: Skipping invalid URL: {line}[/]")
-        else:
-            # Assume it's already in owner/repo#number format
-            refs.append(line)
-
-    return refs
-
-
-def _read_issue_refs_from_stdin() -> list[str]:
-    """Read issue references from stdin, converting URLs to owner/repo#number format.
-
-    Accepts both formats:
-    - GitHub issue URLs: https://github.com/owner/repo/issues/123
-    - Direct refs: owner/repo#123
-
-    Returns:
-        List of issue references in owner/repo#number format
+        List of references in owner/repo#number format
     """
     import re
 
     refs = []
+    pattern = rf"https://github\.com/([^/]+/[^/]+)/{item_type}/(\d+)"
+
     for line in sys.stdin:
         line = line.strip()
         if not line:
             continue
 
-        # Check if it's a GitHub issue URL
+        # Check if it's a GitHub URL
         if line.startswith("https://github.com/"):
-            match = re.match(r"https://github\.com/([^/]+/[^/]+)/issues/(\d+)", line)
+            match = re.match(pattern, line)
             if match:
                 repo_slug = match.group(1)
-                issue_number = match.group(2)
-                refs.append(f"{repo_slug}#{issue_number}")
+                number = match.group(2)
+                refs.append(f"{repo_slug}#{number}")
             else:
                 console.print(f"[yellow]Warning: Skipping invalid URL: {line}[/]")
         else:
@@ -2340,6 +2315,22 @@ def _read_issue_refs_from_stdin() -> list[str]:
             refs.append(line)
 
     return refs
+
+
+def _read_pr_refs_from_stdin() -> list[str]:
+    """Read PR references from stdin.
+
+    Wrapper for _read_refs_from_stdin('pull') for backward compatibility.
+    """
+    return _read_refs_from_stdin("pull")
+
+
+def _read_issue_refs_from_stdin() -> list[str]:
+    """Read issue references from stdin.
+
+    Wrapper for _read_refs_from_stdin('issues') for backward compatibility.
+    """
+    return _read_refs_from_stdin("issues")
 
 
 if __name__ == "__main__":

--- a/src/issue/__init__.py
+++ b/src/issue/__init__.py
@@ -1,0 +1,1 @@
+"""Issue history visualization module."""

--- a/src/issue/cli/__init__.py
+++ b/src/issue/cli/__init__.py
@@ -1,0 +1,5 @@
+"""CLI commands for issue history."""
+
+from src.issue.cli.list_cmd import cmd_list
+
+__all__ = ["cmd_list"]

--- a/src/issue/cli/list_cmd.py
+++ b/src/issue/cli/list_cmd.py
@@ -1,0 +1,191 @@
+"""Issue list command - show issues with history visualization."""
+
+import logging
+import traceback
+
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+from src.issue.github_api import IssueClient
+from src.issue.models import IssueInfo, IssueState
+
+console = Console()
+logger = logging.getLogger(__name__)
+
+
+def cmd_list(
+    *,
+    author: str | None = None,
+    repos: list[str] | None = None,
+    issue_refs: list[str] | None = None,
+    states: list[str] | None = None,
+    labels: list[str] | None = None,
+    board_name: str | None = None,
+    limit: int = 100,
+    show_title: bool = False,
+    sort_by_activity: bool = False,
+) -> int:
+    """List issues with history visualization.
+
+    Args:
+        author: Filter by issue author (use "me" for current user, default)
+        repos: List of repos to filter by (owner/repo format)
+        issue_refs: Specific issue references (owner/repo#number format)
+        states: Filter by state (open, closed)
+        labels: Filter by labels (comma-separated = OR, multiple = AND)
+        board_name: Board to get repos from (default: default board)
+        limit: Maximum number of issues to show
+        show_title: Include issue titles in output
+        sort_by_activity: Sort by recent activity instead of creation date
+
+    Returns:
+        Exit code (0 for success)
+    """
+    try:
+        with IssueClient() as client:
+            # Determine which use case we're handling
+            if issue_refs:
+                # Specific issues by reference
+                result = client.get_issues_by_ref(issue_refs)
+            else:
+                # Issues by author (default: current user)
+                target_repos = _get_repos(repos, board_name)
+                target_author = author or "me"
+                result = client.list_issues_by_author(
+                    target_author,
+                    repos=target_repos,
+                    states=states,
+                    labels=labels,
+                    limit=limit,
+                    sort_by_activity=sort_by_activity,
+                )
+
+            if not result.issues:
+                console.print("[dim]No issues found.[/]")
+                return 0
+
+            _print_issue_table(result.issues, show_title=show_title)
+
+            # Print legend
+            console.print()
+            console.print(
+                "[dim]History: o=opened, c/C=comment, l/L=label, B=bot, "
+                "a=assigned, x=closed, r=reopened, p=PR linked[/]"
+            )
+            console.print("[dim]lowercase=you, UPPERCASE=others[/]")
+
+            if result.has_more:
+                console.print(
+                    f"\n[dim]Showing {len(result.issues)} of {result.total_count} issues[/]"
+                )
+
+            return 0
+
+    except Exception as e:
+        logger.debug("Full traceback:\n%s", traceback.format_exc())
+        console.print(f"[red]Error:[/] {e}")
+        console.print("[dim]Run with --verbose for full traceback[/]")
+        return 1
+
+
+def _get_repos(
+    repos: list[str] | None,
+    board_name: str | None,
+) -> list[str] | None:
+    """Get list of repos to query.
+
+    Priority:
+    1. Explicit --repo flags
+    2. Board repos (from --board or default board)
+    3. None (all GitHub)
+    """
+    if repos:
+        return repos
+
+    # Try to use board repos by default
+    from src.pr.config import get_repos
+
+    board_repos = get_repos(board_name)
+    return board_repos if board_repos else None
+
+
+def _print_issue_table(issues: list[IssueInfo], *, show_title: bool = False) -> None:
+    """Print issues in a formatted table."""
+    table = Table(box=box.SIMPLE, show_header=True, header_style="bold")
+
+    table.add_column("Repo", style="cyan", no_wrap=True)
+    table.add_column("Issue", justify="right", no_wrap=True)
+    if show_title:
+        table.add_column("Title", no_wrap=True, overflow="ellipsis", max_width=35)
+    table.add_column("History", no_wrap=True)
+    table.add_column("PR", no_wrap=True)
+    table.add_column("Labels", no_wrap=True, overflow="ellipsis", max_width=25)
+    table.add_column("State", no_wrap=True)
+    table.add_column("Age", no_wrap=True)
+    table.add_column("Last", no_wrap=True)
+
+    for issue in issues:
+        row = [
+            issue.repo,
+            f"#{issue.number}",
+        ]
+        if show_title:
+            row.append(issue.title or "")
+        row.extend(
+            [
+                issue.history,
+                _format_linked_pr(issue.linked_pr),
+                _format_labels(issue.labels),
+                _format_state(issue.state),
+                _format_duration(issue.age_seconds),
+                _format_relative_time(issue.last_activity_seconds),
+            ]
+        )
+        table.add_row(*row)
+
+    console.print(table)
+
+
+def _format_linked_pr(linked_pr: str | None) -> str:
+    """Format linked PR reference."""
+    if not linked_pr:
+        return "[dim]--[/]"
+    # Extract just the #number part for brevity
+    if "#" in linked_pr:
+        return f"[green]#{linked_pr.split('#')[1]}[/]"
+    return f"[green]{linked_pr}[/]"
+
+
+def _format_labels(labels: list[str]) -> str:
+    """Format labels for display."""
+    if not labels:
+        return "[dim]--[/]"
+    return ",".join(labels)
+
+
+def _format_state(state: IssueState) -> str:
+    """Format issue state with color."""
+    if state == IssueState.OPEN:
+        return "[green]open[/]"
+    else:
+        return "[dim]closed[/]"
+
+
+def _format_duration(seconds: float) -> str:
+    """Format duration in compact form (e.g., '3d', '2h', '45m')."""
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    elif seconds < 3600:
+        return f"{int(seconds / 60)}m"
+    elif seconds < 86400:
+        return f"{int(seconds / 3600)}h"
+    else:
+        days = int(seconds / 86400)
+        return f"{days}d"
+
+
+def _format_relative_time(seconds: float) -> str:
+    """Format relative time (e.g., '3d ago', '2h ago')."""
+    duration = _format_duration(seconds)
+    return f"{duration} ago"

--- a/src/issue/cli/list_cmd.py
+++ b/src/issue/cli/list_cmd.py
@@ -104,7 +104,7 @@ def _get_repos(
         return repos
 
     # Try to use board repos by default
-    from src.pr.config import get_repos
+    from src.repo.config import get_repos
 
     board_repos = get_repos(board_name)
     return board_repos if board_repos else None

--- a/src/issue/config.py
+++ b/src/issue/config.py
@@ -1,0 +1,62 @@
+"""Issue-specific configuration management.
+
+Configuration is stored in ~/.lxa/config.toml under the [issue] section.
+
+Configuration structure:
+    [issue]
+    bot_usernames = ["github-actions[bot]", "stale[bot]", "dependabot[bot]"]
+"""
+
+from src.board.config import CONFIG_FILE
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+# Default bot usernames - any username ending in [bot] is also detected
+DEFAULT_BOT_USERNAMES = [
+    "github-actions[bot]",
+    "stale[bot]",
+    "dependabot[bot]",
+    "renovate[bot]",
+    "allcontributors[bot]",
+    "codecov[bot]",
+    "sonarcloud[bot]",
+]
+
+
+def _load_issue_section() -> dict:
+    """Load the [issue] section from config file."""
+    if not CONFIG_FILE.exists():
+        return {}
+    with open(CONFIG_FILE, "rb") as f:
+        data = tomllib.load(f)
+    return data.get("issue", {})
+
+
+def get_bot_usernames() -> list[str]:
+    """Get list of bot usernames from config.
+
+    Returns config value if set, otherwise returns defaults.
+    """
+    config = _load_issue_section()
+    return config.get("bot_usernames", DEFAULT_BOT_USERNAMES)
+
+
+def is_bot_user(username: str) -> bool:
+    """Check if a username belongs to a bot.
+
+    Detection rules:
+    1. Username ends with [bot]
+    2. Username is in the configured bot_usernames list
+    """
+    username_lower = username.lower()
+
+    # Rule 1: Ends with [bot]
+    if username_lower.endswith("[bot]"):
+        return True
+
+    # Rule 2: In configured list
+    bot_usernames = get_bot_usernames()
+    return username_lower in [b.lower() for b in bot_usernames]

--- a/src/issue/config.py
+++ b/src/issue/config.py
@@ -44,6 +44,10 @@ def get_bot_usernames() -> list[str]:
     return config.get("bot_usernames", DEFAULT_BOT_USERNAMES)
 
 
+# Cached lowercase bot usernames to avoid repeated list comprehensions
+_bot_usernames_lower: list[str] | None = None
+
+
 def is_bot_user(username: str) -> bool:
     """Check if a username belongs to a bot.
 
@@ -51,6 +55,10 @@ def is_bot_user(username: str) -> bool:
     1. Username ends with [bot]
     2. Username is in the configured bot_usernames list
     """
+    global _bot_usernames_lower
+    if _bot_usernames_lower is None:
+        _bot_usernames_lower = [b.lower() for b in get_bot_usernames()]
+
     username_lower = username.lower()
 
     # Rule 1: Ends with [bot]
@@ -58,5 +66,4 @@ def is_bot_user(username: str) -> bool:
         return True
 
     # Rule 2: In configured list
-    bot_usernames = get_bot_usernames()
-    return username_lower in [b.lower() for b in bot_usernames]
+    return username_lower in _bot_usernames_lower

--- a/src/issue/github_api.py
+++ b/src/issue/github_api.py
@@ -1,0 +1,388 @@
+"""GitHub API interactions for issue history."""
+
+import logging
+
+from src.board.github_api import GitHubClient, get_github_token, get_github_username
+from src.issue.models import IssueInfo, IssueListResult
+
+logger = logging.getLogger(__name__)
+
+# GraphQL fragment for issue fields we need
+ISSUE_FIELDS_FRAGMENT = """
+fragment IssueFields on Issue {
+    number
+    title
+    state
+    createdAt
+    closedAt
+    author { login }
+    repository { nameWithOwner }
+    labels(first: 20) {
+        nodes { name }
+    }
+    timelineItems(first: 100, itemTypes: [
+        ISSUE_COMMENT,
+        LABELED_EVENT,
+        CLOSED_EVENT,
+        REOPENED_EVENT,
+        ASSIGNED_EVENT,
+        CROSS_REFERENCED_EVENT
+    ]) {
+        nodes {
+            __typename
+            ... on IssueComment {
+                author { login }
+                createdAt
+            }
+            ... on LabeledEvent {
+                actor { login }
+                label { name }
+                createdAt
+            }
+            ... on ClosedEvent {
+                actor { login }
+                createdAt
+            }
+            ... on ReopenedEvent {
+                actor { login }
+                createdAt
+            }
+            ... on AssignedEvent {
+                actor { login }
+                assignee {
+                    ... on User { login }
+                    ... on Bot { login }
+                    ... on Mannequin { login }
+                }
+                createdAt
+            }
+            ... on CrossReferencedEvent {
+                source {
+                    __typename
+                    ... on PullRequest {
+                        number
+                        repository { nameWithOwner }
+                        state
+                    }
+                }
+                actor { login }
+                createdAt
+            }
+        }
+    }
+}
+"""
+
+
+class IssueClient:
+    """Client for fetching issue data with timeline history."""
+
+    def __init__(self, token: str | None = None):
+        self.token = token or get_github_token()
+        self._client = GitHubClient(self.token)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "IssueClient":
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
+    def get_current_user(self) -> str:
+        """Get the current authenticated user's login."""
+        return get_github_username() or self._client.get_authenticated_user()
+
+    def list_issues_by_author(
+        self,
+        author: str,
+        repos: list[str] | None = None,
+        states: list[str] | None = None,
+        labels: list[str] | None = None,
+        limit: int = 100,
+        sort_by_activity: bool = False,
+    ) -> IssueListResult:
+        """List issues by author, optionally filtered by repos, states, and labels.
+
+        Args:
+            author: GitHub username (or "me" for current user)
+            repos: List of "owner/repo" strings to filter by
+            states: List of states to include ("open", "closed")
+            labels: List of label filters (comma-separated = OR, multiple args = AND)
+            limit: Maximum number of issues to fetch
+            sort_by_activity: If True, sort by last activity; else by created date
+
+        Returns:
+            IssueListResult with processed issue info
+        """
+        if author == "me":
+            author = self.get_current_user()
+
+        # Parse label filters
+        and_labels, or_groups = parse_label_filters(labels or [])
+
+        # Build search query (AND labels go in query, OR handled client-side)
+        search_query = _build_search_query(author, repos, states, and_labels)
+
+        return self._search_issues(
+            search_query,
+            author,
+            limit,
+            or_groups=or_groups,
+            sort_by_activity=sort_by_activity,
+        )
+
+    def get_issues_by_ref(
+        self,
+        issue_refs: list[str],
+        reference_user: str | None = None,
+    ) -> IssueListResult:
+        """Get specific issues by reference (owner/repo#number).
+
+        Args:
+            issue_refs: List of issue references like "owner/repo#123"
+            reference_user: User for determining action case (default: current user)
+
+        Returns:
+            IssueListResult with processed issue info
+        """
+        if reference_user is None:
+            reference_user = self.get_current_user()
+
+        # Parse refs
+        parsed = []
+        for ref in issue_refs:
+            if "#" not in ref:
+                logger.warning(f"Invalid issue reference: {ref}")
+                continue
+            repo_part, num_part = ref.rsplit("#", 1)
+            try:
+                number = int(num_part)
+                parsed.append((repo_part, number))
+            except ValueError:
+                logger.warning(f"Invalid issue number in reference: {ref}")
+                continue
+
+        if not parsed:
+            return IssueListResult()
+
+        # Batch query
+        issues = self._fetch_issues_batched(parsed, reference_user)
+
+        # Sort by created_at descending
+        issues.sort(key=lambda i: i.created_at, reverse=True)
+
+        return IssueListResult(issues=issues, total_count=len(issues))
+
+    def _search_issues(
+        self,
+        search_query: str,
+        reference_user: str,
+        limit: int,
+        or_groups: list[list[str]] | None = None,
+        sort_by_activity: bool = False,
+    ) -> IssueListResult:
+        """Execute a search query and process results."""
+        from src.issue.history import process_issue_data
+
+        query = f"""
+        {ISSUE_FIELDS_FRAGMENT}
+        query($query: String!, $limit: Int!, $cursor: String) {{
+            search(query: $query, type: ISSUE, first: $limit, after: $cursor) {{
+                issueCount
+                pageInfo {{
+                    hasNextPage
+                    endCursor
+                }}
+                nodes {{
+                    ... on Issue {{
+                        ...IssueFields
+                    }}
+                }}
+            }}
+        }}
+        """
+
+        all_issues: list[IssueInfo] = []
+        cursor: str | None = None
+        total_count = 0
+
+        # If we have OR groups, we may need to fetch more and filter
+        fetch_multiplier = 2 if or_groups else 1
+
+        while len(all_issues) < limit:
+            batch_limit = min(100, (limit - len(all_issues)) * fetch_multiplier)
+            data = self._client.graphql(
+                query,
+                {"query": search_query, "limit": batch_limit, "cursor": cursor},
+            )
+            search_result = data["search"]
+            total_count = search_result["issueCount"]
+
+            for node in search_result["nodes"]:
+                if node:
+                    # Skip PRs that might appear in search results
+                    if node.get("__typename") == "PullRequest":
+                        continue
+                    issue_info = process_issue_data(node, reference_user)
+
+                    # Apply OR label filters client-side
+                    if or_groups and not _matches_or_labels(issue_info.labels, or_groups):
+                        continue
+
+                    all_issues.append(issue_info)
+                    if len(all_issues) >= limit:
+                        break
+
+            page_info = search_result["pageInfo"]
+            if not page_info["hasNextPage"] or len(all_issues) >= limit:
+                break
+            cursor = page_info["endCursor"]
+
+        # Sort
+        if sort_by_activity:
+            all_issues.sort(key=lambda i: i.last_activity, reverse=True)
+        else:
+            all_issues.sort(key=lambda i: i.created_at, reverse=True)
+
+        return IssueListResult(
+            issues=all_issues[:limit],
+            total_count=total_count,
+            has_more=total_count > len(all_issues),
+            cursor=cursor,
+        )
+
+    def _fetch_issues_batched(
+        self,
+        issue_refs: list[tuple[str, int]],
+        reference_user: str,
+        batch_size: int = 20,
+    ) -> list[IssueInfo]:
+        """Fetch issues in batches using aliased queries."""
+        all_issues: list[IssueInfo] = []
+
+        for i in range(0, len(issue_refs), batch_size):
+            batch = issue_refs[i : i + batch_size]
+            issues = self._fetch_issue_batch(batch, reference_user)
+            all_issues.extend(issues)
+
+        return all_issues
+
+    def _fetch_issue_batch(
+        self,
+        issue_refs: list[tuple[str, int]],
+        reference_user: str,
+    ) -> list[IssueInfo]:
+        """Fetch a single batch of issues."""
+        from src.issue.history import process_issue_data
+
+        if not issue_refs:
+            return []
+
+        # Build aliased query
+        query_parts = [ISSUE_FIELDS_FRAGMENT]
+        query_parts.append("query {")
+
+        for idx, (repo, number) in enumerate(issue_refs):
+            owner, name = repo.split("/", 1)
+            alias = f"issue{idx}"
+            query_parts.append(f"""
+                {alias}: repository(owner: "{owner}", name: "{name}") {{
+                    issue(number: {number}) {{
+                        ...IssueFields
+                    }}
+                }}
+            """)
+
+        query_parts.append("}")
+        query = "\n".join(query_parts)
+
+        data = self._client.graphql(query, {})
+
+        issues: list[IssueInfo] = []
+        for idx, (repo, number) in enumerate(issue_refs):
+            alias = f"issue{idx}"
+            repo_data = data.get(alias)
+            if repo_data and repo_data.get("issue"):
+                issue_info = process_issue_data(repo_data["issue"], reference_user)
+                issues.append(issue_info)
+            else:
+                logger.warning(f"Issue not found: {repo}#{number}")
+
+        return issues
+
+
+def _build_search_query(
+    author: str,
+    repos: list[str] | None,
+    states: list[str] | None,
+    and_labels: list[str] | None,
+) -> str:
+    """Build GitHub search query for issues."""
+    parts = ["is:issue", f"author:{author}"]
+
+    if repos:
+        for repo in repos:
+            parts.append(f"repo:{repo}")
+
+    if states:
+        states_set = {s.lower() for s in states}
+        if states_set == {"open"}:
+            parts.append("is:open")
+        elif states_set == {"closed"}:
+            parts.append("is:closed")
+        # If both or neither, no filter needed
+
+    if and_labels:
+        for label in and_labels:
+            if " " in label:
+                parts.append(f'label:"{label}"')
+            else:
+                parts.append(f"label:{label}")
+
+    return " ".join(parts)
+
+
+def parse_label_filters(label_args: list[str]) -> tuple[list[str], list[list[str]]]:
+    """Parse label arguments into AND labels and OR label groups.
+
+    Args:
+        label_args: List of label arguments (e.g., ["bug", "stale,wontfix", "urgent"])
+
+    Returns:
+        Tuple of (and_labels, or_groups):
+        - and_labels: Labels that must all be present
+        - or_groups: Groups where at least one label must be present
+
+    Example:
+        parse_label_filters(["bug", "stale,wontfix", "urgent"])
+        -> (["bug", "urgent"], [["stale", "wontfix"]])
+
+        Meaning: must have "bug" AND "urgent" AND (stale OR wontfix)
+    """
+    and_labels = []
+    or_groups = []
+
+    for arg in label_args:
+        if "," in arg:
+            or_groups.append([label.strip() for label in arg.split(",")])
+        else:
+            and_labels.append(arg.strip())
+
+    return and_labels, or_groups
+
+
+def _matches_or_labels(issue_labels: list[str], or_groups: list[list[str]]) -> bool:
+    """Check if issue labels match all OR groups.
+
+    Each OR group must have at least one matching label.
+    """
+    issue_labels_lower = {lbl.lower() for lbl in issue_labels}
+
+    for or_group in or_groups:
+        group_lower = {lbl.lower() for lbl in or_group}
+        if not issue_labels_lower & group_lower:
+            return False
+
+    return True

--- a/src/issue/history.py
+++ b/src/issue/history.py
@@ -1,0 +1,241 @@
+"""Issue timeline processing and history string generation."""
+
+from datetime import datetime
+
+from src.issue.config import is_bot_user
+from src.issue.models import IssueActionType, IssueInfo, IssueState, TimelineEvent
+
+
+def process_issue_data(issue_data: dict, reference_user: str) -> IssueInfo:
+    """Process raw issue data from GraphQL into IssueInfo.
+
+    Args:
+        issue_data: Raw issue data from GraphQL query
+        reference_user: User for determining action case (lowercase = this user)
+
+    Returns:
+        Processed IssueInfo object
+    """
+    repo = issue_data["repository"]["nameWithOwner"]
+    number = issue_data["number"]
+    title = issue_data["title"]
+    author = issue_data["author"]["login"] if issue_data["author"] else "ghost"
+    created_at = _parse_datetime(issue_data["createdAt"])
+    closed_at = _parse_datetime(issue_data["closedAt"]) if issue_data.get("closedAt") else None
+
+    # Determine state
+    state = IssueState.CLOSED if issue_data["state"] == "CLOSED" else IssueState.OPEN
+
+    # Extract labels (alphabetically sorted)
+    labels_data = issue_data.get("labels", {}).get("nodes", [])
+    labels = sorted([lbl["name"] for lbl in labels_data if lbl])
+
+    # Process timeline into history string and find linked PR
+    events, linked_pr = _extract_timeline_events(issue_data, author)
+    history = _build_history_string(events, reference_user)
+
+    # Find last activity time
+    last_activity = _find_last_activity(events, created_at)
+
+    return IssueInfo(
+        repo=repo,
+        number=number,
+        title=title,
+        state=state,
+        history=history,
+        linked_pr=linked_pr,
+        labels=labels,
+        created_at=created_at,
+        closed_at=closed_at,
+        last_activity=last_activity,
+        author=author,
+    )
+
+
+def _parse_datetime(dt_str: str) -> datetime:
+    """Parse ISO datetime string from GitHub."""
+    dt_str = dt_str.replace("Z", "+00:00")
+    return datetime.fromisoformat(dt_str)
+
+
+def _extract_timeline_events(
+    issue_data: dict, issue_author: str
+) -> tuple[list[TimelineEvent], str | None]:
+    """Extract timeline events and find linked PR.
+
+    Returns:
+        Tuple of (events, linked_pr_ref)
+    """
+    events: list[TimelineEvent] = []
+    linked_prs: list[tuple[str, str]] = []  # (ref, state)
+
+    # Add the "opened" event
+    created_at = _parse_datetime(issue_data["createdAt"])
+    events.append(
+        TimelineEvent(
+            action=IssueActionType.OPENED,
+            actor=issue_author,
+            timestamp=created_at,
+        )
+    )
+
+    timeline_items = issue_data.get("timelineItems", {}).get("nodes", [])
+
+    for item in timeline_items:
+        if not item:
+            continue
+
+        typename = item.get("__typename")
+        event = _parse_timeline_item(typename, item, issue_author)
+        if event:
+            events.append(event)
+
+        # Track cross-referenced PRs
+        if typename == "CrossReferencedEvent":
+            pr_ref = _extract_pr_reference(item)
+            if pr_ref:
+                linked_prs.append(pr_ref)
+
+    # Sort by timestamp
+    events.sort(key=lambda e: e.timestamp)
+
+    # Find best linked PR (prefer non-closed)
+    linked_pr = _select_linked_pr(linked_prs)
+
+    return events, linked_pr
+
+
+def _parse_timeline_item(
+    typename: str,
+    item: dict,
+    issue_author: str,  # noqa: ARG001
+) -> TimelineEvent | None:
+    """Parse a single timeline item into an event."""
+    if typename == "IssueComment":
+        actor = item.get("author", {}).get("login", "ghost") if item.get("author") else "ghost"
+        timestamp = _parse_datetime(item["createdAt"])
+        action = IssueActionType.BOT_COMMENT if is_bot_user(actor) else IssueActionType.COMMENT
+        return TimelineEvent(action=action, actor=actor, timestamp=timestamp)
+
+    elif typename == "LabeledEvent":
+        actor = item.get("actor", {}).get("login", "ghost") if item.get("actor") else "ghost"
+        timestamp = _parse_datetime(item["createdAt"])
+        return TimelineEvent(action=IssueActionType.LABELED, actor=actor, timestamp=timestamp)
+
+    elif typename == "ClosedEvent":
+        actor = item.get("actor", {}).get("login", "ghost") if item.get("actor") else "ghost"
+        timestamp = _parse_datetime(item["createdAt"])
+        return TimelineEvent(action=IssueActionType.CLOSED, actor=actor, timestamp=timestamp)
+
+    elif typename == "ReopenedEvent":
+        actor = item.get("actor", {}).get("login", "ghost") if item.get("actor") else "ghost"
+        timestamp = _parse_datetime(item["createdAt"])
+        return TimelineEvent(action=IssueActionType.REOPENED, actor=actor, timestamp=timestamp)
+
+    elif typename == "AssignedEvent":
+        actor = item.get("actor", {}).get("login", "ghost") if item.get("actor") else "ghost"
+        timestamp = _parse_datetime(item["createdAt"])
+        return TimelineEvent(action=IssueActionType.ASSIGNED, actor=actor, timestamp=timestamp)
+
+    elif typename == "CrossReferencedEvent":
+        # Check if source is a PR
+        source = item.get("source")
+        if source and source.get("__typename") == "PullRequest":
+            actor = item.get("actor", {}).get("login", "ghost") if item.get("actor") else "ghost"
+            timestamp = _parse_datetime(item["createdAt"])
+            return TimelineEvent(action=IssueActionType.PR_LINKED, actor=actor, timestamp=timestamp)
+
+    return None
+
+
+def _extract_pr_reference(item: dict) -> tuple[str, str] | None:
+    """Extract PR reference from CrossReferencedEvent."""
+    source = item.get("source")
+    if not source:
+        return None
+
+    # Only interested in PRs
+    if source.get("__typename") != "PullRequest":
+        return None
+
+    number = source.get("number")
+    repo_data = source.get("repository")
+    state = source.get("state", "OPEN")
+
+    if number and repo_data:
+        repo = repo_data.get("nameWithOwner")
+        if repo:
+            return (f"{repo}#{number}", state)
+
+    return None
+
+
+def _select_linked_pr(prs: list[tuple[str, str]]) -> str | None:
+    """Select the best linked PR from candidates.
+
+    Prefers open/merged PRs over closed ones.
+    """
+    if not prs:
+        return None
+
+    # Prefer non-CLOSED PRs
+    for pr_ref, state in prs:
+        if state != "CLOSED":
+            return pr_ref
+
+    # Fall back to first PR
+    return prs[0][0]
+
+
+def _deduplicate_consecutive(events: list[TimelineEvent]) -> list[TimelineEvent]:
+    """Remove consecutive duplicate action types."""
+    if not events:
+        return []
+
+    result: list[TimelineEvent] = [events[0]]
+    for event in events[1:]:
+        if event.action != result[-1].action:
+            result.append(event)
+    return result
+
+
+def _format_action(action: IssueActionType, actor: str, reference_user: str) -> str:
+    """Convert action to case-appropriate character.
+
+    - BOT_COMMENT is always uppercase "B"
+    - Other actions: lowercase = reference_user, uppercase = others
+    """
+    char = action.value
+
+    # BOT_COMMENT is always uppercase
+    if action == IssueActionType.BOT_COMMENT:
+        return char
+
+    is_reference_user = actor.lower() == reference_user.lower()
+    if not is_reference_user:
+        char = char.upper()
+    return char
+
+
+def _build_history_string(
+    events: list[TimelineEvent],
+    reference_user: str,
+) -> str:
+    """Build the compact history string from timeline events.
+
+    Rules:
+    - Lowercase = action by reference_user
+    - Uppercase = action by someone else
+    - BOT_COMMENT is always "B"
+    - Consecutive duplicates are collapsed
+    """
+    deduped = _deduplicate_consecutive(events)
+    return "".join(_format_action(e.action, e.actor, reference_user) for e in deduped)
+
+
+def _find_last_activity(events: list[TimelineEvent], created_at: datetime) -> datetime:
+    """Find the timestamp of the most recent activity."""
+    if not events:
+        return created_at
+
+    return max(e.timestamp for e in events)

--- a/src/issue/history.py
+++ b/src/issue/history.py
@@ -86,7 +86,7 @@ def _extract_timeline_events(
             continue
 
         typename = item.get("__typename")
-        event = _parse_timeline_item(typename, item, issue_author)
+        event = _parse_timeline_item(typename, item)
         if event:
             events.append(event)
 
@@ -108,7 +108,6 @@ def _extract_timeline_events(
 def _parse_timeline_item(
     typename: str,
     item: dict,
-    issue_author: str,  # noqa: ARG001
 ) -> TimelineEvent | None:
     """Parse a single timeline item into an event."""
     if typename == "IssueComment":

--- a/src/issue/models.py
+++ b/src/issue/models.py
@@ -1,0 +1,78 @@
+"""Data models for issue history visualization."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+
+class IssueActionType(Enum):
+    """Issue timeline action types."""
+
+    OPENED = "o"
+    COMMENT = "c"
+    BOT_COMMENT = "B"  # Always uppercase
+    LABELED = "l"
+    ASSIGNED = "a"
+    CLOSED = "x"
+    REOPENED = "r"
+    PR_LINKED = "p"
+
+
+class IssueState(Enum):
+    """Issue state values."""
+
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+@dataclass
+class TimelineEvent:
+    """A single event in the issue timeline."""
+
+    action: IssueActionType
+    actor: str
+    timestamp: datetime
+
+
+@dataclass
+class IssueInfo:
+    """Processed issue information for display."""
+
+    repo: str
+    number: int
+    title: str
+    state: IssueState
+    history: str  # Compact history string like "oClCBx"
+    linked_pr: str | None  # "owner/repo#123" or None
+    labels: list[str]  # Alphabetically sorted labels
+    created_at: datetime
+    closed_at: datetime | None
+    last_activity: datetime
+    author: str
+
+    @property
+    def age_seconds(self) -> float:
+        """Time from open to close (or now if open)."""
+        end = self.closed_at or datetime.now(self.created_at.tzinfo)
+        return (end - self.created_at).total_seconds()
+
+    @property
+    def last_activity_seconds(self) -> float:
+        """Time since last activity."""
+        now = datetime.now(self.last_activity.tzinfo)
+        return (now - self.last_activity).total_seconds()
+
+    @property
+    def labels_display(self) -> str:
+        """Comma-separated labels for display."""
+        return ",".join(self.labels) if self.labels else "--"
+
+
+@dataclass
+class IssueListResult:
+    """Result of an issue list query."""
+
+    issues: list[IssueInfo] = field(default_factory=list)
+    total_count: int = 0
+    has_more: bool = False
+    cursor: str | None = None

--- a/tests/issue/__init__.py
+++ b/tests/issue/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for issue module."""

--- a/tests/issue/test_config.py
+++ b/tests/issue/test_config.py
@@ -1,0 +1,51 @@
+"""Tests for issue config."""
+
+from src.issue.config import (
+    DEFAULT_BOT_USERNAMES,
+    get_bot_usernames,
+    is_bot_user,
+)
+
+
+class TestGetBotUsernames:
+    """Tests for get_bot_usernames function."""
+
+    def test_returns_default_when_no_config(self):
+        """Test that defaults are returned when no config exists."""
+        # This will use defaults since no config is set
+        usernames = get_bot_usernames()
+        assert isinstance(usernames, list)
+        assert len(usernames) > 0
+
+    def test_default_bots_included(self):
+        """Verify expected bots are in defaults."""
+        assert "github-actions[bot]" in DEFAULT_BOT_USERNAMES
+        assert "stale[bot]" in DEFAULT_BOT_USERNAMES
+        assert "dependabot[bot]" in DEFAULT_BOT_USERNAMES
+
+
+class TestIsBotUser:
+    """Tests for is_bot_user function."""
+
+    def test_detects_bot_suffix(self):
+        """Test detection of [bot] suffix."""
+        assert is_bot_user("some-bot[bot]") is True
+        assert is_bot_user("CUSTOM-BOT[BOT]") is True
+        assert is_bot_user("test[bot]") is True
+
+    def test_detects_known_bots(self):
+        """Test detection of known bot usernames."""
+        assert is_bot_user("github-actions[bot]") is True
+        assert is_bot_user("stale[bot]") is True
+        assert is_bot_user("dependabot[bot]") is True
+
+    def test_rejects_regular_users(self):
+        """Test that regular users are not detected as bots."""
+        assert is_bot_user("regularuser") is False
+        assert is_bot_user("john-smith") is False
+        assert is_bot_user("bot-lover") is False  # has "bot" but no [bot]
+
+    def test_case_insensitive(self):
+        """Test that detection is case-insensitive."""
+        assert is_bot_user("GitHub-Actions[Bot]") is True
+        assert is_bot_user("STALE[BOT]") is True

--- a/tests/issue/test_github_api.py
+++ b/tests/issue/test_github_api.py
@@ -1,0 +1,122 @@
+"""Tests for issue GitHub API functions."""
+
+from src.issue.github_api import (
+    _build_search_query,
+    _matches_or_labels,
+    parse_label_filters,
+)
+
+
+class TestParseLabelFilters:
+    """Tests for parse_label_filters function."""
+
+    def test_empty_list(self):
+        """Test with empty list."""
+        and_labels, or_groups = parse_label_filters([])
+        assert and_labels == []
+        assert or_groups == []
+
+    def test_simple_and_labels(self):
+        """Test simple AND labels."""
+        and_labels, or_groups = parse_label_filters(["bug", "urgent"])
+        assert and_labels == ["bug", "urgent"]
+        assert or_groups == []
+
+    def test_simple_or_group(self):
+        """Test comma-separated OR group."""
+        and_labels, or_groups = parse_label_filters(["bug,stale"])
+        assert and_labels == []
+        assert or_groups == [["bug", "stale"]]
+
+    def test_mixed_and_or(self):
+        """Test mix of AND labels and OR groups."""
+        and_labels, or_groups = parse_label_filters(["bug", "stale,wontfix", "urgent"])
+        assert and_labels == ["bug", "urgent"]
+        assert or_groups == [["stale", "wontfix"]]
+
+    def test_strips_whitespace(self):
+        """Test that whitespace is stripped."""
+        and_labels, or_groups = parse_label_filters(["  bug  ", " stale , wontfix "])
+        assert and_labels == ["bug"]
+        assert or_groups == [["stale", "wontfix"]]
+
+    def test_multiple_or_groups(self):
+        """Test multiple OR groups."""
+        and_labels, or_groups = parse_label_filters(["bug,fix", "P1,P2"])
+        assert and_labels == []
+        assert or_groups == [["bug", "fix"], ["P1", "P2"]]
+
+
+class TestMatchesOrLabels:
+    """Tests for _matches_or_labels function."""
+
+    def test_empty_or_groups_matches_all(self):
+        """Test that empty OR groups match all issues."""
+        assert _matches_or_labels(["bug"], []) is True
+        assert _matches_or_labels([], []) is True
+
+    def test_matches_single_or_group(self):
+        """Test matching a single OR group."""
+        or_groups = [["bug", "fix"]]
+        assert _matches_or_labels(["bug"], or_groups) is True
+        assert _matches_or_labels(["fix"], or_groups) is True
+        assert _matches_or_labels(["enhancement"], or_groups) is False
+
+    def test_matches_multiple_or_groups(self):
+        """Test that all OR groups must match."""
+        or_groups = [["bug", "fix"], ["P1", "P2"]]
+        # Has bug (matches first group) and P1 (matches second group)
+        assert _matches_or_labels(["bug", "P1"], or_groups) is True
+        # Has bug but no P1/P2
+        assert _matches_or_labels(["bug"], or_groups) is False
+        # Has P1 but no bug/fix
+        assert _matches_or_labels(["P1"], or_groups) is False
+
+    def test_case_insensitive(self):
+        """Test that matching is case-insensitive."""
+        or_groups = [["Bug", "Fix"]]
+        assert _matches_or_labels(["bug"], or_groups) is True
+        assert _matches_or_labels(["BUG"], or_groups) is True
+
+
+class TestBuildSearchQuery:
+    """Tests for _build_search_query function."""
+
+    def test_basic_query(self):
+        """Test basic query with author."""
+        query = _build_search_query("testuser", None, None, None)
+        assert "is:issue" in query
+        assert "author:testuser" in query
+
+    def test_with_repos(self):
+        """Test query with repos."""
+        query = _build_search_query("testuser", ["owner/repo1", "owner/repo2"], None, None)
+        assert "repo:owner/repo1" in query
+        assert "repo:owner/repo2" in query
+
+    def test_with_open_state(self):
+        """Test query with open state filter."""
+        query = _build_search_query("testuser", None, ["open"], None)
+        assert "is:open" in query
+
+    def test_with_closed_state(self):
+        """Test query with closed state filter."""
+        query = _build_search_query("testuser", None, ["closed"], None)
+        assert "is:closed" in query
+
+    def test_with_both_states(self):
+        """Test query with both states (no filter needed)."""
+        query = _build_search_query("testuser", None, ["open", "closed"], None)
+        assert "is:open" not in query
+        assert "is:closed" not in query
+
+    def test_with_and_labels(self):
+        """Test query with AND labels."""
+        query = _build_search_query("testuser", None, None, ["bug", "urgent"])
+        assert "label:bug" in query
+        assert "label:urgent" in query
+
+    def test_with_label_containing_space(self):
+        """Test query with label containing space."""
+        query = _build_search_query("testuser", None, None, ["help wanted"])
+        assert 'label:"help wanted"' in query

--- a/tests/issue/test_history.py
+++ b/tests/issue/test_history.py
@@ -1,0 +1,253 @@
+"""Tests for issue history processing."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.issue.history import (
+    _build_history_string,
+    _deduplicate_consecutive,
+    _find_last_activity,
+    _format_action,
+    _parse_datetime,
+    _select_linked_pr,
+    process_issue_data,
+)
+from src.issue.models import IssueActionType, IssueState, TimelineEvent
+
+
+class TestParseDatetime:
+    """Tests for _parse_datetime function."""
+
+    def test_parse_iso_with_z(self):
+        """Test parsing ISO datetime with Z suffix."""
+        dt = _parse_datetime("2024-01-15T10:30:00Z")
+        assert dt.year == 2024
+        assert dt.month == 1
+        assert dt.day == 15
+        assert dt.hour == 10
+        assert dt.minute == 30
+
+    def test_parse_iso_with_offset(self):
+        """Test parsing ISO datetime with timezone offset."""
+        dt = _parse_datetime("2024-01-15T10:30:00+00:00")
+        assert dt.year == 2024
+        assert dt.tzinfo is not None
+
+
+class TestFormatAction:
+    """Tests for _format_action function."""
+
+    def test_lowercase_for_reference_user(self):
+        """Test that reference user actions are lowercase."""
+        char = _format_action(IssueActionType.COMMENT, "testuser", "testuser")
+        assert char == "c"
+
+    def test_uppercase_for_other_user(self):
+        """Test that other user actions are uppercase."""
+        char = _format_action(IssueActionType.COMMENT, "otheruser", "testuser")
+        assert char == "C"
+
+    def test_case_insensitive_user_comparison(self):
+        """Test that user comparison is case-insensitive."""
+        char = _format_action(IssueActionType.COMMENT, "TestUser", "testuser")
+        assert char == "c"
+
+    def test_bot_comment_always_uppercase(self):
+        """Test that BOT_COMMENT is always B (uppercase)."""
+        # Even if actor matches reference user, BOT_COMMENT stays uppercase
+        char = _format_action(IssueActionType.BOT_COMMENT, "testuser", "testuser")
+        assert char == "B"
+
+
+class TestDeduplicateConsecutive:
+    """Tests for _deduplicate_consecutive function."""
+
+    def test_empty_list(self):
+        """Test with empty list."""
+        result = _deduplicate_consecutive([])
+        assert result == []
+
+    def test_no_duplicates(self):
+        """Test with no consecutive duplicates."""
+        now = datetime.now(UTC)
+        events = [
+            TimelineEvent(IssueActionType.OPENED, "user1", now),
+            TimelineEvent(IssueActionType.COMMENT, "user1", now),
+            TimelineEvent(IssueActionType.LABELED, "user1", now),
+        ]
+        result = _deduplicate_consecutive(events)
+        assert len(result) == 3
+
+    def test_removes_consecutive_duplicates(self):
+        """Test that consecutive duplicates are removed."""
+        now = datetime.now(UTC)
+        events = [
+            TimelineEvent(IssueActionType.OPENED, "user1", now),
+            TimelineEvent(IssueActionType.COMMENT, "user1", now),
+            TimelineEvent(IssueActionType.COMMENT, "user2", now),  # Same action type
+            TimelineEvent(IssueActionType.LABELED, "user1", now),
+        ]
+        result = _deduplicate_consecutive(events)
+        assert len(result) == 3
+        assert result[0].action == IssueActionType.OPENED
+        assert result[1].action == IssueActionType.COMMENT
+        assert result[2].action == IssueActionType.LABELED
+
+
+class TestSelectLinkedPr:
+    """Tests for _select_linked_pr function."""
+
+    def test_empty_list(self):
+        """Test with no PRs."""
+        result = _select_linked_pr([])
+        assert result is None
+
+    def test_prefers_open_pr(self):
+        """Test that open PRs are preferred over closed."""
+        prs = [
+            ("owner/repo#1", "CLOSED"),
+            ("owner/repo#2", "OPEN"),
+            ("owner/repo#3", "CLOSED"),
+        ]
+        result = _select_linked_pr(prs)
+        assert result == "owner/repo#2"
+
+    def test_prefers_merged_over_closed(self):
+        """Test that merged PRs are preferred over closed."""
+        prs = [
+            ("owner/repo#1", "CLOSED"),
+            ("owner/repo#2", "MERGED"),
+        ]
+        result = _select_linked_pr(prs)
+        assert result == "owner/repo#2"
+
+    def test_falls_back_to_first_if_all_closed(self):
+        """Test fallback to first PR if all are closed."""
+        prs = [
+            ("owner/repo#1", "CLOSED"),
+            ("owner/repo#2", "CLOSED"),
+        ]
+        result = _select_linked_pr(prs)
+        assert result == "owner/repo#1"
+
+
+class TestFindLastActivity:
+    """Tests for _find_last_activity function."""
+
+    def test_empty_events_returns_created_at(self):
+        """Test that empty events returns created_at."""
+        created = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        result = _find_last_activity([], created)
+        assert result == created
+
+    def test_returns_latest_timestamp(self):
+        """Test that latest timestamp is returned."""
+        t1 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        t2 = datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC)
+        t3 = datetime(2024, 1, 3, 12, 0, 0, tzinfo=UTC)
+        events = [
+            TimelineEvent(IssueActionType.OPENED, "user1", t1),
+            TimelineEvent(IssueActionType.COMMENT, "user1", t3),  # Latest
+            TimelineEvent(IssueActionType.LABELED, "user1", t2),
+        ]
+        result = _find_last_activity(events, t1)
+        assert result == t3
+
+
+class TestBuildHistoryString:
+    """Tests for _build_history_string function."""
+
+    def test_basic_history(self):
+        """Test basic history string generation."""
+        now = datetime.now(UTC)
+        events = [
+            TimelineEvent(IssueActionType.OPENED, "author", now),
+            TimelineEvent(IssueActionType.COMMENT, "other", now),
+            TimelineEvent(IssueActionType.CLOSED, "author", now),
+        ]
+        result = _build_history_string(events, "author")
+        assert result == "oCx"
+
+    def test_bot_comment_always_uppercase(self):
+        """Test that bot comments are always B."""
+        now = datetime.now(UTC)
+        events = [
+            TimelineEvent(IssueActionType.OPENED, "author", now),
+            TimelineEvent(IssueActionType.BOT_COMMENT, "stale[bot]", now),
+        ]
+        result = _build_history_string(events, "author")
+        assert result == "oB"
+
+
+class TestProcessIssueData:
+    """Tests for process_issue_data function."""
+
+    @pytest.fixture
+    def sample_issue_data(self):
+        """Create sample issue data from GraphQL response."""
+        return {
+            "number": 123,
+            "title": "Test issue title",
+            "state": "OPEN",
+            "createdAt": "2024-01-15T10:00:00Z",
+            "closedAt": None,
+            "author": {"login": "testauthor"},
+            "repository": {"nameWithOwner": "owner/repo"},
+            "labels": {
+                "nodes": [
+                    {"name": "bug"},
+                    {"name": "enhancement"},
+                ]
+            },
+            "timelineItems": {
+                "nodes": [
+                    {
+                        "__typename": "IssueComment",
+                        "author": {"login": "commenter"},
+                        "createdAt": "2024-01-15T11:00:00Z",
+                    },
+                    {
+                        "__typename": "LabeledEvent",
+                        "actor": {"login": "labeler"},
+                        "label": {"name": "bug"},
+                        "createdAt": "2024-01-15T12:00:00Z",
+                    },
+                ]
+            },
+        }
+
+    def test_processes_basic_fields(self, sample_issue_data):
+        """Test that basic fields are processed correctly."""
+        result = process_issue_data(sample_issue_data, "testauthor")
+        assert result.repo == "owner/repo"
+        assert result.number == 123
+        assert result.title == "Test issue title"
+        assert result.state == IssueState.OPEN
+        assert result.author == "testauthor"
+
+    def test_processes_labels_alphabetically(self, sample_issue_data):
+        """Test that labels are sorted alphabetically."""
+        result = process_issue_data(sample_issue_data, "testauthor")
+        assert result.labels == ["bug", "enhancement"]
+
+    def test_builds_history_string(self, sample_issue_data):
+        """Test that history string is built."""
+        result = process_issue_data(sample_issue_data, "testauthor")
+        # Should have: o (opened), C (comment by other), L (labeled by other)
+        assert "o" in result.history
+        assert len(result.history) > 0
+
+    def test_handles_closed_state(self, sample_issue_data):
+        """Test handling of closed issues."""
+        sample_issue_data["state"] = "CLOSED"
+        sample_issue_data["closedAt"] = "2024-01-16T10:00:00Z"
+        result = process_issue_data(sample_issue_data, "testauthor")
+        assert result.state == IssueState.CLOSED
+        assert result.closed_at is not None
+
+    def test_handles_missing_author(self, sample_issue_data):
+        """Test handling when author is None (deleted user)."""
+        sample_issue_data["author"] = None
+        result = process_issue_data(sample_issue_data, "testauthor")
+        assert result.author == "ghost"

--- a/tests/issue/test_models.py
+++ b/tests/issue/test_models.py
@@ -1,0 +1,127 @@
+"""Tests for issue models."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.issue.models import (
+    IssueActionType,
+    IssueInfo,
+    IssueListResult,
+    IssueState,
+    TimelineEvent,
+)
+
+
+class TestIssueActionType:
+    """Tests for IssueActionType enum."""
+
+    def test_action_values(self):
+        """Verify all action type character values."""
+        assert IssueActionType.OPENED.value == "o"
+        assert IssueActionType.COMMENT.value == "c"
+        assert IssueActionType.BOT_COMMENT.value == "B"
+        assert IssueActionType.LABELED.value == "l"
+        assert IssueActionType.ASSIGNED.value == "a"
+        assert IssueActionType.CLOSED.value == "x"
+        assert IssueActionType.REOPENED.value == "r"
+        assert IssueActionType.PR_LINKED.value == "p"
+
+
+class TestIssueState:
+    """Tests for IssueState enum."""
+
+    def test_state_values(self):
+        """Verify state values."""
+        assert IssueState.OPEN.value == "open"
+        assert IssueState.CLOSED.value == "closed"
+
+
+class TestTimelineEvent:
+    """Tests for TimelineEvent dataclass."""
+
+    def test_create_event(self):
+        """Test creating a timeline event."""
+        timestamp = datetime.now(UTC)
+        event = TimelineEvent(
+            action=IssueActionType.COMMENT,
+            actor="testuser",
+            timestamp=timestamp,
+        )
+        assert event.action == IssueActionType.COMMENT
+        assert event.actor == "testuser"
+        assert event.timestamp == timestamp
+
+
+class TestIssueInfo:
+    """Tests for IssueInfo dataclass."""
+
+    @pytest.fixture
+    def sample_issue(self):
+        """Create a sample issue for testing."""
+        now = datetime.now(UTC)
+        return IssueInfo(
+            repo="owner/repo",
+            number=123,
+            title="Test issue",
+            state=IssueState.OPEN,
+            history="oClCx",
+            linked_pr="owner/repo#456",
+            labels=["bug", "enhancement"],
+            created_at=now,
+            closed_at=None,
+            last_activity=now,
+            author="testuser",
+        )
+
+    def test_labels_display_with_labels(self, sample_issue):
+        """Test labels_display with labels present."""
+        assert sample_issue.labels_display == "bug,enhancement"
+
+    def test_labels_display_empty(self, sample_issue):
+        """Test labels_display with no labels."""
+        sample_issue.labels = []
+        assert sample_issue.labels_display == "--"
+
+    def test_age_seconds_open_issue(self, sample_issue):
+        """Test age calculation for open issue."""
+        # Age should be positive (time from creation to now)
+        assert sample_issue.age_seconds > 0
+
+    def test_age_seconds_closed_issue(self, sample_issue):
+        """Test age calculation for closed issue."""
+        created = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        closed = datetime(2024, 1, 2, 12, 0, 0, tzinfo=UTC)
+        sample_issue.created_at = created
+        sample_issue.closed_at = closed
+        # Should be exactly 24 hours = 86400 seconds
+        assert sample_issue.age_seconds == 86400
+
+    def test_last_activity_seconds(self, sample_issue):
+        """Test last_activity_seconds calculation."""
+        # Should be positive (time from last activity to now)
+        assert sample_issue.last_activity_seconds >= 0
+
+
+class TestIssueListResult:
+    """Tests for IssueListResult dataclass."""
+
+    def test_default_values(self):
+        """Test default values."""
+        result = IssueListResult()
+        assert result.issues == []
+        assert result.total_count == 0
+        assert result.has_more is False
+        assert result.cursor is None
+
+    def test_with_values(self):
+        """Test with values provided."""
+        result = IssueListResult(
+            issues=[],
+            total_count=100,
+            has_more=True,
+            cursor="abc123",
+        )
+        assert result.total_count == 100
+        assert result.has_more is True
+        assert result.cursor == "abc123"


### PR DESCRIPTION
## Summary

Adds a new `lxa issue` command that provides visibility into GitHub issues with a compact history visualization, similar to the existing `lxa pr` and `lxa review` commands.

## Features

### Command Structure
```
lxa issue list [options] [OWNER/REPO#NUM ...]
```

### Display
```
Repo                Issue   History   PR    Labels        State    Age   Last
───────────────────────────────────────────────────────────────────────────────
jpshackelford/lxa     #81   o         --    --            open     7d    7d ago
jpshackelford/lxa     #76   opx       #77   --            closed   1d    7d ago
jpshackelford/lxa     #36   oclcpCx   #37   enhancement   closed   4d    54d ago
```

### History String Characters

| Char | Meaning |
|------|---------|
| `o` | Issue opened |
| `c/C` | Comment (lowercase=you, uppercase=others) |
| `B` | Bot comment (always uppercase) |
| `l/L` | Label added |
| `a` | Assigned |
| `x` | Closed |
| `r` | Reopened |
| `p` | PR linked |

### Options

- `--author/-a USER` - Filter by issue author (default: current user)
- `--repo OWNER/REPO` - Filter by repo (repeatable)
- `--board/-b NAME` - Use repos from specified board
- `--label/-l LABEL` - Filter by label with AND/OR semantics
- `--open/-O` - Show open issues (default)
- `--closed/-C` - Show closed issues
- `--all/-A` - Show all states
- `--limit/-n N` - Max issues (default: 100)
- `--title/-t` - Show issue titles
- `--activity/-s` - Sort by recent activity instead of creation date

### Label Filtering

Supports flexible AND/OR semantics:
- **AND:** `-l bug -l urgent` (must have both labels)
- **OR:** `-l bug,stale` (must have at least one)
- **Combined:** `-l bug -l P1,P2` (must have bug AND (P1 OR P2))

### Bot Detection

Bot comments are marked with `B` in the history string. Detection rules:
1. Username ends with `[bot]`
2. Username is in configurable list (`~/.lxa/config.toml` under `[issue]` section)

Default bots: `github-actions[bot]`, `stale[bot]`, `dependabot[bot]`, `renovate[bot]`, etc.

### Additional Features

- **Linked PR column:** Shows cross-referenced PRs that implement the issue
- **Stdin support:** Pipe issue URLs or refs for batch processing
- **Board integration:** Uses default board repos when no `--repo` specified

## Files Changed

- `src/issue/` - New module with models, history processing, GitHub API, CLI
- `src/__main__.py` - CLI parser additions
- `tests/issue/` - 55 unit tests
- `doc/design/issue-command-proposal.md` - Design document

## Testing

All CI checks pass:
- ✅ Lint (ruff)
- ✅ Type check (basedpyright)  
- ✅ Tests (1164 passed)

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/78c47869-798c-4959-bfbb-b969ed5cf6f6)